### PR TITLE
feat: add status bar controls and completion toggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,8 +187,24 @@
           "type": "string",
           "default": "en",
           "description": "language: bg - Bulgarian (Български), cn - Chinese (中文), en - English, fr - French (Français), de - German (Deutsch), ru - Russian (Русский), es - Spanish (Español)"
+        },
+        "llama-vscode.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable completions"
+        },
+      
+        "llama-vscode.languageSettings": {
+            "type": "object",
+            "default": {
+              "*": true
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "description": "Enable/disable suggestions for specific languages"
+          }
         }
-      }
     }
   },
   "dependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 export class Configuration {
     // extension configs
+    enabled = true
     endpoint = "http=//127.0.0.1:8012"
     auto = true
     api_key = ""
@@ -20,6 +21,7 @@ export class Configuration {
     language = "en"
     // additional configs
     axiosRequestConfig = {}
+    disabledLanguages: string[] = []
     RING_UPDATE_MIN_TIME_LAST_COMPL = 3000
     MIN_TIME_BETWEEN_COMPL = 600
     MAX_LAST_PICK_LINE_DISTANCE = 32
@@ -88,6 +90,8 @@ export class Configuration {
         this.ring_scope = Number(config.get<number>("ring_scope"));
         this.ring_update_ms = Number(config.get<number>("ring_update_ms"));
         this.language = String(config.get<string>("language"));
+        this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
+        this.enabled = Boolean(config.get<boolean>("enabled", true));
     }
 
     getUiText = (uiText: string): string | undefined => {


### PR DESCRIPTION
Resolves #5 

- Add status bar menu with completion settings
- Implement global and per-language completion toggles
- Add visual indicators for completion status, if completion is disabled then the user can see a cross icon.

https://github.com/user-attachments/assets/e1aa5f90-4d33-4570-9c60-63b7a1fff333