### PR TITLE
config : enable show_info by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "llama-vscode",
   "displayName": "llama-vscode",
   "description": "Local LLM-assisted text completion using llama.cpp",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "ggml-org",
   "repository": "https://github.com/ggml-org/llama.vscode",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
         },
         "llama-vscode.show_info": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "show extra info about the inference (false - disabled, true - show extra info in status line)"
         },
         "llama-vscode.max_line_suffix": {


### PR DESCRIPTION
Enable detailed inference information in the status bar:

<img width="996" alt="image" src="https://github.com/user-attachments/assets/3d5d076a-4c87-4074-a86b-496c60879adc" />
