### PR TITLE
ability to auto start a cmd (e.g. llama-server) with vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
       "type": "object",
       "title": "llama.vscode Configuration",
       "properties": {
+        "llama-vscode.launch_cmd": {
+          "type": "string",
+          "default": "llama-server.exe -m qwen2.5-coder-7b-q8_0.gguf --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256",
+          "description": "Shell command executed on Plugin start."
+        },
         "llama-vscode.endpoint": {
           "type": "string",
           "default": "http://127.0.0.1:8012",

--- a/src/architect.ts
+++ b/src/architect.ts
@@ -38,6 +38,23 @@ export class Architect {
         this.lruResultCache = new LRUCache(this.extConfig.max_cache_keys);
     }
 
+    launchCmd = (context: vscode.ExtensionContext) => {
+        let configurationChangeDisp = vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration("llama-vscode.launch_cmd")) {
+                this.llamaServer.killCmd();
+                this.llamaServer.launchCmd();
+            }
+        });
+        context.subscriptions.push(configurationChangeDisp);
+        
+        this.llamaServer.onlaunchCmdClose((data) => {
+            vscode.window.showErrorMessage(`llama-vscode launchCmd Process closed, code: ${data.code}, stderr: ${data.stderr}`);
+        });
+
+        this.llamaServer.launchCmd();
+
+    }
+
     setStatusBar = (context: vscode.ExtensionContext) => {
         this.initializeStatusBar();
         this.registerEventListeners(context);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 export class Configuration {
     // extension configs
     enabled = true
+    launch_cmd = ""
     endpoint = "http=//127.0.0.1:8012"
     auto = true
     api_key = ""
@@ -74,6 +75,7 @@ export class Configuration {
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
         // TODO Handle the case of wrong types for the configuration values
+        this.launch_cmd = String(config.get<string>("launch_cmd"));
         this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
         this.auto = Boolean(config.get<boolean>("auto"));
         this.api_key = String(config.get<string>("api_key"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { Architect } from './architect';
 
 export function activate(context: vscode.ExtensionContext) {
     let architect = new Architect();
-
+    architect.launchCmd(context)
     architect.setStatusBar(context)
     architect.setOnChangeConfiguration(context);
     architect.setCompletionProvider(context);


### PR DESCRIPTION
Added a config item llama-vscode.launch_cmd that accepts a full cmd line as written in the shell/cmd prompt.
The Cmd is started on plugin activation and restarted whenever the launch_cmd config changes
When the Cmd exits, there is a toast message stating exit code and stderr