### PR TITLE
Adds OpenAI compatible endpoint option

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "printWidth": 140,
+    "tabWidth": 4,
+    "useTabs": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,11 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
-	},
-	"search.exclude": {
-		"out": true // set this to false to include "out" folder in search results
-	},
-	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
 }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ Here are recommended settings, depending on the amount of VRAM that you have:
       --ctx-size 0 --cache-reuse 256
   ```
 
+<details>
+  <summary>CPU-only configs</summary>
+
+These are `llama-server` settings for CPU-only hardware. Note that the quality will be significantly lower:
+
+```bash
+llama-server \
+    -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF \
+    --port 8012 -ub 512 -b 512 --ctx-size 0 --cache-reuse 256
+```
+
+```bash
+llama-server \
+    -hf ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF \
+    --port 8012 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256
+```
+</details>
+
 You can use any other FIM-compatible model that your system can handle. By default, the models downloaded with the `-hf` flag are stored in:
 
 - Mac OS: `~/Library/Caches/llama.cpp/`

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ The plugin requires FIM-compatible models: [HF collection](https://huggingface.c
 
 ## Examples
 
-TODO: add examples
+Speculative FIMs running locally on a M2 Studio:
 
+https://github.com/user-attachments/assets/cab99b93-4712-40b4-9c8d-cf86e98d4482
 
 ## Implementation details
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llama-vscode",
-  "version": "0.0.1",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llama-vscode",
-      "version": "0.0.1",
+      "version": "0.0.6",
       "dependencies": {
         "axios": "^1.1.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "llama-vscode",
       "version": "0.0.6",
       "dependencies": {
-        "axios": "^1.1.2"
+        "axios": "^1.1.2",
+        "openai": "^4.80.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -250,10 +251,19 @@
       "version": "18.19.67",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.67.tgz",
       "integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -501,6 +511,18 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -512,6 +534,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -870,6 +904,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -978,6 +1021,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1023,6 +1085,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/import-local": {
@@ -1306,6 +1377,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -1313,12 +1390,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "4.80.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.80.1.tgz",
+      "integrity": "sha512-+6+bbXFwbIE88foZsBEt36bPkgZPdyFN82clAXG61gnHb2gXdZApDyRrcAHqEtpYICywpqaNo57kOm9dtnb7Cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/p-try": {
       "version": "2.2.0",
@@ -1780,6 +1926,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1798,7 +1950,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -1855,6 +2006,21 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.97.1",
@@ -2008,6 +2174,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "llama-vscode",
-  "version": "0.0.5",
   "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "llama-vscode",
+  "version": "0.0.5",
   "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "llama-vscode",
   "displayName": "llama-vscode",
   "description": "Local LLM-assisted text completion using llama.cpp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "ggml-org",
   "repository": "https://github.com/ggml-org/llama.vscode",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
     ],
     "keybindings": [
       {
+        "key": "tab",
+        "command": "editor.action.inlineSuggest.commit",
+        "when": "inlineSuggestionVisible"
+      },
+      {
         "command": "extension.triggerInlineCompletion",
         "key": "ctrl+l",
         "when": "editorTextFocus"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
        "llama-vscode.api_key": {
           "type": "string",
           "default": "",
-          "description": "llama.cpp server api key (optional) or OpenAI endpoint API key (required if using OpenAI compatible endpoint)"
+          "description": "llama.cpp server api key or OpenAI endpoint API key (optional)"
         },
         "llama-vscode.is_openai_compatible": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -218,6 +218,9 @@
         }
     }
   },
+  "scripts": {
+    "watch": "tsc -watch -p ./"
+  },
   "dependencies": {
     "axios": "^1.1.2",
     "openai": "^4.80.1"

--- a/package.json
+++ b/package.json
@@ -114,10 +114,25 @@
           "default": true,
           "description": "If code completion should be trggered automatically (true) or only by pressing Ctrl+l."
         },
-        "llama-vscode.api_key": {
+       "llama-vscode.api_key": {
           "type": "string",
           "default": "",
-          "description": "llama.cpp server api key (optional)"
+          "description": "llama.cpp server api key (optional) or OpenAI endpoint API key (required if using OpenAI compatible endpoint)"
+        },
+        "llama-vscode.is_openai_compatible": {
+          "type": "boolean",
+          "default": false,
+          "description": "If the server exposes an OpenAI API compatible endpoint."
+        },
+        "llama-vscode.openai_client_model": {
+          "type": "string",
+          "default": "",
+          "description": "The FIM friendly model supported by your OpenAI compatible endpoint to be used (e.g., Qwen2.5-Coder-14B-4-bit)"
+        },
+        "llama-vscode.openai_prompt_template": {
+          "type": "string",
+          "default": "<|fim_prefix|>{inputPrefix}{prompt}<|fim_suffix|>{inputSuffix}<|fim_middle|>",
+          "description": "The prompt template to be used for the OpenAI compatible endpoint."
         },
         "llama-vscode.n_prefix": {
           "type": "number",
@@ -204,7 +219,8 @@
     }
   },
   "dependencies": {
-    "axios": "^1.1.2"
+    "axios": "^1.1.2",
+    "openai": "^4.80.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/src/architect.ts
+++ b/src/architect.ts
@@ -205,6 +205,10 @@ export class Architect {
                 vscode.window.showErrorMessage('No active editor!');
                 return;
             }
+            // Hide the current suggestion to force VS Code to call the completion provider instead of using cache
+            await vscode.commands.executeCommand('editor.action.inlineSuggest.hide');
+            // Wait a tiny bit to ensure VS Code processes the command
+            await new Promise(resolve => setTimeout(resolve, 50));
             this.isForcedNewRequest = true;
             vscode.commands.executeCommand('editor.action.inlineSuggest.trigger');
         });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode";
 import OpenAI from "openai";
 
 export class Configuration {
-<<<<<<< HEAD
     // extension configs
     enabled = true;
     endpoint = "http=//127.0.0.1:8012";
@@ -34,38 +33,6 @@ export class Configuration {
     MAX_QUEUED_CHUNKS = 16;
     DELAY_BEFORE_COMPL_REQUEST = 150;
     MAX_EVENTS_IN_LOG = 250;
-=======
-  // extension configs
-  enabled = true;
-  endpoint = "http=//127.0.0.1:8012";
-  is_openai_compatible = false;
-  openAiClient: OpenAI | null = null;
-  openAiClientModel: string | null = null;
-  opeanAiPromptTemplate: string = "<|fim_prefix|>{inputPrefix}{prompt}<|fim_suffix|>{inputSuffix}<|fim_middle|>";
-  auto = true;
-  api_key = "";
-  n_prefix = 256;
-  n_suffix = 64;
-  n_predict = 128;
-  t_max_prompt_ms = 500;
-  t_max_predict_ms = 2500;
-  show_info = true;
-  max_line_suffix = 8;
-  max_cache_keys = 250;
-  ring_n_chunks = 16;
-  ring_chunk_size = 64;
-  ring_scope = 1024;
-  ring_update_ms = 1000;
-  language = "en";
-  // additional configs
-  axiosRequestConfig = {};
-  disabledLanguages: string[] = [];
-  RING_UPDATE_MIN_TIME_LAST_COMPL = 3000;
-  MIN_TIME_BETWEEN_COMPL = 600;
-  MAX_LAST_PICK_LINE_DISTANCE = 32;
-  MAX_QUEUED_CHUNKS = 16;
-  DELAY_BEFORE_COMPL_REQUEST = 150;
->>>>>>> 52135f7 (fixed config and completions to work with FIM models by default)
 
     private languageBg = new Map<string, string>([
         ["no suggestion", "нямам предложение"],
@@ -106,55 +73,10 @@ export class Configuration {
         ["fr", this.languageFr],
     ]);
 
-<<<<<<< HEAD
     constructor(config: vscode.WorkspaceConfiguration) {
         this.updateConfigs(config);
         this.setLlamaRequestConfig();
         this.setOpenAiClient();
-=======
-  constructor(config: vscode.WorkspaceConfiguration) {
-    this.updateConfigs(config);
-    this.setLlamaRequestConfig();
-    this.setOpenAiClient();
-  }
-
-  private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
-    // TODO Handle the case of wrong types for the configuration values
-    this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
-    this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
-    this.openAiClientModel = String(config.get<string>("openAiClientModel"));
-    this.opeanAiPromptTemplate = String(config.get<string>("opeanAiPromptTemplate"));
-    this.auto = Boolean(config.get<boolean>("auto"));
-    this.api_key = String(config.get<string>("api_key"));
-    this.n_prefix = Number(config.get<number>("n_prefix"));
-    this.n_suffix = Number(config.get<number>("n_suffix"));
-    this.n_predict = Number(config.get<number>("n_predict"));
-    this.t_max_prompt_ms = Number(config.get<number>("t_max_prompt_ms"));
-    this.t_max_predict_ms = Number(config.get<number>("t_max_predict_ms"));
-    this.show_info = Boolean(config.get<boolean>("show_info"));
-    this.max_line_suffix = Number(config.get<number>("max_line_suffix"));
-    this.max_cache_keys = Number(config.get<number>("max_cache_keys"));
-    this.ring_n_chunks = Number(config.get<number>("ring_n_chunks"));
-    this.ring_chunk_size = Number(config.get<number>("ring_chunk_size"));
-    this.ring_scope = Number(config.get<number>("ring_scope"));
-    this.ring_update_ms = Number(config.get<number>("ring_update_ms"));
-    this.language = String(config.get<string>("language"));
-    this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
-    this.enabled = Boolean(config.get<boolean>("enabled", true));
-  };
-
-  getUiText = (uiText: string): string | undefined => {
-    let langTexts = this.languages.get(this.language);
-    if (langTexts == undefined) langTexts = this.languages.get("en");
-    return langTexts?.get(uiText);
-  };
-
-  updateOnEvent = (event: vscode.ConfigurationChangeEvent, config: vscode.WorkspaceConfiguration) => {
-    this.updateConfigs(config);
-    if (event.affectsConfiguration("llama-vscode.api_key")) {
-      this.setLlamaRequestConfig();
-      this.setOpenAiClient();
->>>>>>> 35adb98 (added openAiClientModel to config; tested with local vllm server)
     }
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -73,10 +73,54 @@ export class Configuration {
         ["fr", this.languageFr],
     ]);
 
+<<<<<<< HEAD
     constructor(config: vscode.WorkspaceConfiguration) {
         this.updateConfigs(config);
         this.setLlamaRequestConfig();
         this.setOpenAiClient();
+=======
+  constructor(config: vscode.WorkspaceConfiguration) {
+    this.updateConfigs(config);
+    this.setLlamaRequestConfig();
+    this.setOpenAiClient();
+  }
+
+  private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
+    // TODO Handle the case of wrong types for the configuration values
+    this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
+    this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
+    this.openAiClientModel = String(config.get<string>("openAiClientModel"));
+    this.auto = Boolean(config.get<boolean>("auto"));
+    this.api_key = String(config.get<string>("api_key"));
+    this.n_prefix = Number(config.get<number>("n_prefix"));
+    this.n_suffix = Number(config.get<number>("n_suffix"));
+    this.n_predict = Number(config.get<number>("n_predict"));
+    this.t_max_prompt_ms = Number(config.get<number>("t_max_prompt_ms"));
+    this.t_max_predict_ms = Number(config.get<number>("t_max_predict_ms"));
+    this.show_info = Boolean(config.get<boolean>("show_info"));
+    this.max_line_suffix = Number(config.get<number>("max_line_suffix"));
+    this.max_cache_keys = Number(config.get<number>("max_cache_keys"));
+    this.ring_n_chunks = Number(config.get<number>("ring_n_chunks"));
+    this.ring_chunk_size = Number(config.get<number>("ring_chunk_size"));
+    this.ring_scope = Number(config.get<number>("ring_scope"));
+    this.ring_update_ms = Number(config.get<number>("ring_update_ms"));
+    this.language = String(config.get<string>("language"));
+    this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
+    this.enabled = Boolean(config.get<boolean>("enabled", true));
+  };
+
+  getUiText = (uiText: string): string | undefined => {
+    let langTexts = this.languages.get(this.language);
+    if (langTexts == undefined) langTexts = this.languages.get("en");
+    return langTexts?.get(uiText);
+  };
+
+  updateOnEvent = (event: vscode.ConfigurationChangeEvent, config: vscode.WorkspaceConfiguration) => {
+    this.updateConfigs(config);
+    if (event.affectsConfiguration("llama-vscode.api_key")) {
+      this.setLlamaRequestConfig();
+      this.setOpenAiClient();
+>>>>>>> 35adb98 (added openAiClientModel to config; tested with local vllm server)
     }
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import OpenAI from "openai";
 
 export class Configuration {
+<<<<<<< HEAD
     // extension configs
     enabled = true;
     endpoint = "http=//127.0.0.1:8012";
@@ -33,6 +34,38 @@ export class Configuration {
     MAX_QUEUED_CHUNKS = 16;
     DELAY_BEFORE_COMPL_REQUEST = 150;
     MAX_EVENTS_IN_LOG = 250;
+=======
+  // extension configs
+  enabled = true;
+  endpoint = "http=//127.0.0.1:8012";
+  is_openai_compatible = false;
+  openAiClient: OpenAI | null = null;
+  openAiClientModel: string | null = null;
+  opeanAiPromptTemplate: string = "<|fim_prefix|>{inputPrefix}{prompt}<|fim_suffix|>{inputSuffix}<|fim_middle|>";
+  auto = true;
+  api_key = "";
+  n_prefix = 256;
+  n_suffix = 64;
+  n_predict = 128;
+  t_max_prompt_ms = 500;
+  t_max_predict_ms = 2500;
+  show_info = true;
+  max_line_suffix = 8;
+  max_cache_keys = 250;
+  ring_n_chunks = 16;
+  ring_chunk_size = 64;
+  ring_scope = 1024;
+  ring_update_ms = 1000;
+  language = "en";
+  // additional configs
+  axiosRequestConfig = {};
+  disabledLanguages: string[] = [];
+  RING_UPDATE_MIN_TIME_LAST_COMPL = 3000;
+  MIN_TIME_BETWEEN_COMPL = 600;
+  MAX_LAST_PICK_LINE_DISTANCE = 32;
+  MAX_QUEUED_CHUNKS = 16;
+  DELAY_BEFORE_COMPL_REQUEST = 150;
+>>>>>>> 52135f7 (fixed config and completions to work with FIM models by default)
 
     private languageBg = new Map<string, string>([
         ["no suggestion", "нямам предложение"],
@@ -90,6 +123,7 @@ export class Configuration {
     this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
     this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
     this.openAiClientModel = String(config.get<string>("openAiClientModel"));
+    this.opeanAiPromptTemplate = String(config.get<string>("opeanAiPromptTemplate"));
     this.auto = Boolean(config.get<boolean>("auto"));
     this.api_key = String(config.get<string>("api_key"));
     this.n_prefix = Number(config.get<number>("n_prefix"));

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -141,7 +141,7 @@ export class Configuration {
         this.openai_client = null;
         if (this.is_openai_compatible) {
             const openai = new OpenAI({
-                apiKey: this.api_key || undefined,
+                apiKey: this.api_key || "empty",
                 baseURL: this.endpoint,
             });
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -73,10 +73,55 @@ export class Configuration {
         ["fr", this.languageFr],
     ]);
 
+<<<<<<< HEAD
     constructor(config: vscode.WorkspaceConfiguration) {
         this.updateConfigs(config);
         this.setLlamaRequestConfig();
         this.setOpenAiClient();
+=======
+  constructor(config: vscode.WorkspaceConfiguration) {
+    this.updateConfigs(config);
+    this.setLlamaRequestConfig();
+    this.setOpenAiClient();
+  }
+
+  private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
+    // TODO Handle the case of wrong types for the configuration values
+    this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
+    this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
+    this.openAiClientModel = String(config.get<string>("openAiClientModel"));
+    this.opeanAiPromptTemplate = String(config.get<string>("opeanAiPromptTemplate"));
+    this.auto = Boolean(config.get<boolean>("auto"));
+    this.api_key = String(config.get<string>("api_key"));
+    this.n_prefix = Number(config.get<number>("n_prefix"));
+    this.n_suffix = Number(config.get<number>("n_suffix"));
+    this.n_predict = Number(config.get<number>("n_predict"));
+    this.t_max_prompt_ms = Number(config.get<number>("t_max_prompt_ms"));
+    this.t_max_predict_ms = Number(config.get<number>("t_max_predict_ms"));
+    this.show_info = Boolean(config.get<boolean>("show_info"));
+    this.max_line_suffix = Number(config.get<number>("max_line_suffix"));
+    this.max_cache_keys = Number(config.get<number>("max_cache_keys"));
+    this.ring_n_chunks = Number(config.get<number>("ring_n_chunks"));
+    this.ring_chunk_size = Number(config.get<number>("ring_chunk_size"));
+    this.ring_scope = Number(config.get<number>("ring_scope"));
+    this.ring_update_ms = Number(config.get<number>("ring_update_ms"));
+    this.language = String(config.get<string>("language"));
+    this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
+    this.enabled = Boolean(config.get<boolean>("enabled", true));
+  };
+
+  getUiText = (uiText: string): string | undefined => {
+    let langTexts = this.languages.get(this.language);
+    if (langTexts == undefined) langTexts = this.languages.get("en");
+    return langTexts?.get(uiText);
+  };
+
+  updateOnEvent = (event: vscode.ConfigurationChangeEvent, config: vscode.WorkspaceConfiguration) => {
+    this.updateConfigs(config);
+    if (event.affectsConfiguration("llama-vscode.api_key")) {
+      this.setLlamaRequestConfig();
+      this.setOpenAiClient();
+>>>>>>> 52135f7 (fixed config and completions to work with FIM models by default)
     }
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -73,55 +73,10 @@ export class Configuration {
         ["fr", this.languageFr],
     ]);
 
-<<<<<<< HEAD
     constructor(config: vscode.WorkspaceConfiguration) {
         this.updateConfigs(config);
         this.setLlamaRequestConfig();
         this.setOpenAiClient();
-=======
-  constructor(config: vscode.WorkspaceConfiguration) {
-    this.updateConfigs(config);
-    this.setLlamaRequestConfig();
-    this.setOpenAiClient();
-  }
-
-  private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
-    // TODO Handle the case of wrong types for the configuration values
-    this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
-    this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
-    this.openAiClientModel = String(config.get<string>("openAiClientModel"));
-    this.opeanAiPromptTemplate = String(config.get<string>("opeanAiPromptTemplate"));
-    this.auto = Boolean(config.get<boolean>("auto"));
-    this.api_key = String(config.get<string>("api_key"));
-    this.n_prefix = Number(config.get<number>("n_prefix"));
-    this.n_suffix = Number(config.get<number>("n_suffix"));
-    this.n_predict = Number(config.get<number>("n_predict"));
-    this.t_max_prompt_ms = Number(config.get<number>("t_max_prompt_ms"));
-    this.t_max_predict_ms = Number(config.get<number>("t_max_predict_ms"));
-    this.show_info = Boolean(config.get<boolean>("show_info"));
-    this.max_line_suffix = Number(config.get<number>("max_line_suffix"));
-    this.max_cache_keys = Number(config.get<number>("max_cache_keys"));
-    this.ring_n_chunks = Number(config.get<number>("ring_n_chunks"));
-    this.ring_chunk_size = Number(config.get<number>("ring_chunk_size"));
-    this.ring_scope = Number(config.get<number>("ring_scope"));
-    this.ring_update_ms = Number(config.get<number>("ring_update_ms"));
-    this.language = String(config.get<string>("language"));
-    this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
-    this.enabled = Boolean(config.get<boolean>("enabled", true));
-  };
-
-  getUiText = (uiText: string): string | undefined => {
-    let langTexts = this.languages.get(this.language);
-    if (langTexts == undefined) langTexts = this.languages.get("en");
-    return langTexts?.get(uiText);
-  };
-
-  updateOnEvent = (event: vscode.ConfigurationChangeEvent, config: vscode.WorkspaceConfiguration) => {
-    this.updateConfigs(config);
-    if (event.affectsConfiguration("llama-vscode.api_key")) {
-      this.setLlamaRequestConfig();
-      this.setOpenAiClient();
->>>>>>> 52135f7 (fixed config and completions to work with FIM models by default)
     }
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,33 +1,38 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
+import OpenAI from "openai";
 
 export class Configuration {
     // extension configs
-    enabled = true
-    endpoint = "http=//127.0.0.1:8012"
-    auto = true
-    api_key = ""
-    n_prefix = 256
-    n_suffix = 64
-    n_predict = 128
-    t_max_prompt_ms = 500
-    t_max_predict_ms = 2500
-    show_info = true
-    max_line_suffix = 8
-    max_cache_keys = 250
-    ring_n_chunks = 16
-    ring_chunk_size = 64
-    ring_scope = 1024
-    ring_update_ms = 1000
-    language = "en"
+    enabled = true;
+    endpoint = "http=//127.0.0.1:8012";
+    is_openai_compatible = false;
+    openai_client: OpenAI | null = null;
+    openai_client_model: string = "";
+    openai_prompt_template: string = "<|fim_prefix|>{inputPrefix}{prompt}<|fim_suffix|>{inputSuffix}<|fim_middle|>";
+    auto = true;
+    api_key = "";
+    n_prefix = 256;
+    n_suffix = 64;
+    n_predict = 128;
+    t_max_prompt_ms = 500;
+    t_max_predict_ms = 2500;
+    show_info = true;
+    max_line_suffix = 8;
+    max_cache_keys = 250;
+    ring_n_chunks = 16;
+    ring_chunk_size = 64;
+    ring_scope = 1024;
+    ring_update_ms = 1000;
+    language = "en";
     // additional configs
-    axiosRequestConfig = {}
-    disabledLanguages: string[] = []
-    RING_UPDATE_MIN_TIME_LAST_COMPL = 3000
-    MIN_TIME_BETWEEN_COMPL = 600
-    MAX_LAST_PICK_LINE_DISTANCE = 32
-    MAX_QUEUED_CHUNKS = 16
-    DELAY_BEFORE_COMPL_REQUEST = 150
-    MAX_EVENTS_IN_LOG = 250
+    axiosRequestConfig = {};
+    disabledLanguages: string[] = [];
+    RING_UPDATE_MIN_TIME_LAST_COMPL = 3000;
+    MIN_TIME_BETWEEN_COMPL = 600;
+    MAX_LAST_PICK_LINE_DISTANCE = 32;
+    MAX_QUEUED_CHUNKS = 16;
+    DELAY_BEFORE_COMPL_REQUEST = 150;
+    MAX_EVENTS_IN_LOG = 250;
 
     private languageBg = new Map<string, string>([
         ["no suggestion", "нямам предложение"],
@@ -71,11 +76,15 @@ export class Configuration {
     constructor(config: vscode.WorkspaceConfiguration) {
         this.updateConfigs(config);
         this.setLlamaRequestConfig();
+        this.setOpenAiClient();
     }
 
     private updateConfigs = (config: vscode.WorkspaceConfiguration) => {
         // TODO Handle the case of wrong types for the configuration values
         this.endpoint = this.trimTrailingSlash(String(config.get<string>("endpoint")));
+        this.is_openai_compatible = Boolean(config.get<boolean>("is_openai_compatible"));
+        this.openai_client_model = String(config.get<string>("openai_client_model"));
+        this.openai_prompt_template = String(config.get<string>("openai_prompt_template"));
         this.auto = Boolean(config.get<boolean>("auto"));
         this.api_key = String(config.get<string>("api_key"));
         this.n_prefix = Number(config.get<number>("n_prefix"));
@@ -93,37 +102,50 @@ export class Configuration {
         this.language = String(config.get<string>("language"));
         this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
         this.enabled = Boolean(config.get<boolean>("enabled", true));
-    }
+    };
 
     getUiText = (uiText: string): string | undefined => {
-        let langTexts = this.languages.get(this.language)
-        if (langTexts == undefined) langTexts = this.languages.get("en")
-        return langTexts?.get(uiText)
-    }
+        let langTexts = this.languages.get(this.language);
+        if (langTexts == undefined) langTexts = this.languages.get("en");
+        return langTexts?.get(uiText);
+    };
 
     updateOnEvent = (event: vscode.ConfigurationChangeEvent, config: vscode.WorkspaceConfiguration) => {
         this.updateConfigs(config);
         if (event.affectsConfiguration("llama-vscode.api_key")) {
             this.setLlamaRequestConfig();
+            this.setOpenAiClient();
         }
-    }
+    };
 
     trimTrailingSlash = (s: string): string => {
-        if (s.length > 0 && s[s.length - 1] === '/') {
-            return s.slice(0, - 1);
+        if (s.length > 0 && s[s.length - 1] === "/") {
+            return s.slice(0, -1);
         }
         return s;
-    }
+    };
 
     setLlamaRequestConfig = () => {
         this.axiosRequestConfig = {};
         if (this.api_key != undefined && this.api_key != "") {
             this.axiosRequestConfig = {
                 headers: {
-                    'Authorization': `Bearer ${this.api_key}`,
-                    'Content-Type': 'application/json'
+                    Authorization: `Bearer ${this.api_key}`,
+                    "Content-Type": "application/json",
                 },
             };
         }
-    }
+    };
+
+    setOpenAiClient = () => {
+        this.openai_client = null;
+        if (this.is_openai_compatible && this.api_key != undefined && this.api_key != "") {
+            const openai = new OpenAI({
+                apiKey: this.api_key,
+                baseURL: this.endpoint,
+            });
+
+            this.openai_client = openai;
+        }
+    };
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -139,9 +139,9 @@ export class Configuration {
 
     setOpenAiClient = () => {
         this.openai_client = null;
-        if (this.is_openai_compatible && this.api_key != undefined && this.api_key != "") {
+        if (this.is_openai_compatible) {
             const openai = new OpenAI({
-                apiKey: this.api_key,
+                apiKey: this.api_key || undefined,
                 baseURL: this.endpoint,
             });
 

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -1,7 +1,8 @@
-import axios from 'axios';
-import { Configuration } from './configuration';
+import axios from "axios";
+import { Configuration } from "./configuration";
+import { PassThrough } from "stream";
 
-const STATUS_OK = 200
+const STATUS_OK = 200;
 
 export interface LlamaResponse {
     content?: string;
@@ -18,53 +19,117 @@ export interface LlamaResponse {
     };
 }
 
-export class LlamaServer{
-    private extConfig: Configuration
+export class LlamaServer {
+    private extConfig: Configuration;
+    private readonly defaultRequestParams = {
+        top_k: 40,
+        top_p: 0.99,
+        stream: false,
+        samplers: ["top_k", "top_p", "infill"],
+        cache_prompt: true,
+    } as const;
 
     constructor(config: Configuration) {
-            this.extConfig = config
-        }
+        this.extConfig = config;
+    }
 
-    // Class field is used instead of a function to make "this" available
-    getLlamaCompletion = async (inputPrefix: string, inputSuffix: string, prompt: string, chunks: any, nindent: number): Promise<LlamaResponse | undefined> => {
-        const requestPayload = {
+    private replacePlaceholders(template: string, replacements: { [key: string]: string }): string {
+        return template.replace(/{(\w+)}/g, (_, key) => replacements[key] || "");
+    }
+
+    private async handleOpenAICompletion(
+        chunks: any[],
+        inputPrefix: string,
+        inputSuffix: string,
+        prompt: string,
+        isPreparation = false
+    ): Promise<LlamaResponse | void> {
+        const client = this.extConfig.openai_client;
+        if (!client) return;
+
+        const additional_context = chunks.length > 0 ? "Context:\n\n" + chunks.join("\n") : "";
+
+        const replacements = {
+            inputPrefix: inputPrefix.slice(-this.extConfig.n_prefix),
+            prompt: prompt,
+            inputSuffix: inputSuffix.slice(0, this.extConfig.n_suffix),
+        };
+
+        const rsp = await client.completions.create({
+            model: this.extConfig.openai_client_model || "",
+            prompt: additional_context + this.replacePlaceholders(this.extConfig.openai_prompt_template, replacements),
+            max_tokens: this.extConfig.n_predict,
+            temperature: 0.1,
+            top_p: this.defaultRequestParams.top_p,
+            stream: this.defaultRequestParams.stream,
+        });
+
+        if (isPreparation) return;
+
+        return {
+            content: rsp.choices[0].text,
+            generation_settings: {
+                finish_reason: rsp.choices[0].finish_reason,
+                model: rsp.model,
+                created: rsp.created,
+            },
+            timings: {
+                prompt_ms: rsp.usage?.prompt_tokens,
+                predicted_ms: rsp.usage?.completion_tokens,
+                predicted_n: rsp.usage?.total_tokens,
+            },
+        };
+    }
+
+    private createRequestPayload(inputPrefix: string, inputSuffix: string, chunks: any[], prompt: string, nindent?: number) {
+        return {
             input_prefix: inputPrefix,
             input_suffix: inputSuffix,
             input_extra: chunks,
-            prompt: prompt,
+            prompt,
             n_predict: this.extConfig.n_predict,
-            // Basic sampling parameters (adjust as needed)
-            top_k: 40,
-            top_p: 0.99,
-            stream: false,
-            n_indent: nindent,
-            samplers: ["top_k", "top_p", "infill"],
-            cache_prompt: true,
+            ...this.defaultRequestParams,
+            ...(nindent && { n_indent: nindent }),
             t_max_prompt_ms: this.extConfig.t_max_prompt_ms,
-            t_max_predict_ms: this.extConfig.t_max_predict_ms
+            t_max_predict_ms: this.extConfig.t_max_predict_ms,
         };
-        const response = await axios.post<LlamaResponse>(this.extConfig.endpoint + "/infill", requestPayload, this.extConfig.axiosRequestConfig);
-        if (response.status != STATUS_OK || !response.data ) return undefined
-        else return response.data;
     }
+
+    getLlamaCompletion = async (
+        inputPrefix: string,
+        inputSuffix: string,
+        prompt: string,
+        chunks: any,
+        nindent: number
+    ): Promise<LlamaResponse | undefined> => {
+        // If the server is OpenAI compatible, use the OpenAI API to get the completion
+        if (this.extConfig.is_openai_compatible) {
+            const response = await this.handleOpenAICompletion(chunks, inputPrefix, inputSuffix, prompt);
+            return response || undefined;
+        }
+
+        // else, default to llama.cpp
+        const response = await axios.post<LlamaResponse>(
+            `${this.extConfig.endpoint}/infill`,
+            this.createRequestPayload(inputPrefix, inputSuffix, chunks, prompt, nindent),
+            this.extConfig.axiosRequestConfig
+        );
+
+        return response.status === STATUS_OK ? response.data : undefined;
+    };
 
     prepareLlamaForNextCompletion = (chunks: any[]): void => {
-        // Make a request to the API to prepare for the next FIM
-        const requestPayload = {
-            input_prefix: "",
-            input_suffix: "",
-            input_extra: chunks,
-            prompt: "",
-            n_predict: 1,
-            top_k: 40,
-            top_p: 0.99,
-            stream: false,
-            samplers: ["temperature"],
-            cache_prompt: true,
-            t_max_prompt_ms: 1,
-            t_max_predict_ms: 1
-        };
+        // If the server is OpenAI compatible, use the OpenAI API to prepare for the next FIM
+        if (this.extConfig.is_openai_compatible) {
+            this.handleOpenAICompletion(chunks, "", "", "", true);
+            return;
+        }
 
-        axios.post<LlamaResponse>(this.extConfig.endpoint + "/infill", requestPayload, this.extConfig.axiosRequestConfig);
-    }
+        // else, make a request to the API to prepare for the next FIM
+        axios.post<LlamaResponse>(
+            `${this.extConfig.endpoint}/infill`,
+            this.createRequestPayload("", "", chunks, "", undefined),
+            this.extConfig.axiosRequestConfig
+        );
+    };
 }

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -121,7 +121,8 @@ export class LlamaServer {
     prepareLlamaForNextCompletion = (chunks: any[]): void => {
         // If the server is OpenAI compatible, use the OpenAI API to prepare for the next FIM
         if (this.extConfig.is_openai_compatible) {
-            this.handleOpenAICompletion(chunks, "", "", "", true);
+            // wtg 20250207 - per @igardev ... "This makes sense only if there is a server cache"
+            // this.handleOpenAICompletion(chunks, "", "", "", true);
             return;
         }
 


### PR DESCRIPTION
This PR enables llama-vscode to talk to a OpenAI compatible endpoint in lieu of llama.cpp running locally.

Tested with OpenAI's exposed enpoint as well as a local vLLM server endpoint.

I'm not sure if I translated all the llama.cpp arguments correctly for an OpenAI API so I imagine we might have to do a few iterations to get the hypers and prompt right.  I'm relatively new to this extension and to llama.cpp so definitely up for taking as much time to get this right.

Thanks much - wg