### PR TITLE
core : fix requests

### DIFF
--- a/src/architect.ts
+++ b/src/architect.ts
@@ -383,7 +383,7 @@ export class Architect {
                 }
                 this.showThinkingInfo();
 
-                data = await this.llamaServer.getLlamaCompletion(inputPrefix, inputSuffix, prompt, this.extraContext.chunks, nindent)
+                data = await this.llamaServer.getFIMCompletion(inputPrefix, inputSuffix, prompt, this.extraContext.chunks, nindent)
                 if (data != undefined) completion = data.content;
                 else completion = undefined
             }
@@ -551,7 +551,7 @@ export class Architect {
         let futureHashKey = this.lruResultCache.getHash(futureInputPrefix + "|" + futureInputSuffix + "|" + futurePrompt)
         let cached_completion = this.lruResultCache.get(futureHashKey)
         if (cached_completion != undefined) return;
-        let futureData = await this.llamaServer.getLlamaCompletion(futureInputPrefix, futureInputSuffix, futurePrompt, this.extraContext.chunks, prompt.length - prompt.trimStart().length);
+        let futureData = await this.llamaServer.getFIMCompletion(futureInputPrefix, futureInputSuffix, futurePrompt, this.extraContext.chunks, prompt.length - prompt.trimStart().length);
         let futureSuggestion = "";
         if (futureData != undefined && futureData.content != undefined && futureData.content.trim() != "") {
             futureSuggestion = futureData.content;

--- a/src/extra-context.ts
+++ b/src/extra-context.ts
@@ -35,7 +35,7 @@ export class ExtraContext {
             }
         }
 
-        this.llamaServer.prepareLlamaForNextCompletion(this.chunks)
+        this.llamaServer.updateExtraContext(this.chunks)
     };
 
     // Class field is used instead of a function to make "this" available


### PR DESCRIPTION
#16 introduced a regression in the requests used to prepare the extra context. They should look like this:

```json
{
    "input_prefix": "",
    "input_suffix": "",
    "input_extra": [
        {
            "text": "some text\n",
            "time": 1739023864786,
            "filename": "some/file.cpp"
        },
        ...
    ],
    "prompt": "",
    "n_predict": 0,
    "samplers": [],
    "cache_prompt": true,
    "t_max_prompt_ms": 500,
    "t_max_predict_ms": 1
}
```