### PR TITLE
Refine git commit message generation logic to handle multiple repos

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -21,44 +21,44 @@ export class Git {
             vscode.window.showErrorMessage('can`t use on non git dir');
             return;
         }
-        const repo = git.repositories[0];
-
-        try {
-            let diff = await repo.diff(true);
-
-            if (!diff || diff.trim() === '') {
-                // use unstaged change
-                diff = await repo.diff(false);
+        for (const repo of git.repositories) {
+            try {
+                let diff = await repo.diff(true);
+    
                 if (!diff || diff.trim() === '') {
-                    vscode.window.showWarningMessage('git diff is empty');
-                    return;
-                }
-                vscode.window.showWarningMessage('git staged change is empty, using unstaged change');
-            }
-
-            const prompt = this.app.prompts.replaceOnePlaceholders(this.app.prompts.CREATE_GIT_DIFF_COMMIT, "diff", diff);
-            vscode.window.withProgress({
-                location: vscode.ProgressLocation.SourceControl,
-                title: 'llama.vscode is generating a commit message...',
-                cancellable: false
-            }, async (progress) => {
-                try {
-                    // TODO stream output the commit message, need for llamaServer with stream output support
-                    const completion = await this.app.llamaServer.getChatCompletion(prompt)
-                    const commitMessage = completion?.choices[0]?.message.content
-
-                    if (commitMessage) {
-                        repo.inputBox.value = commitMessage;
-                    } else {
-                        vscode.window.showErrorMessage('unexpected error for generating commit message is empty');
+                    // use unstaged change
+                    diff = await repo.diff(false);
+                    if (!diff || diff.trim() === '') {
+                        vscode.window.showWarningMessage('git diff is empty');
+                        continue;
                     }
-                } catch (error) {
-                    vscode.window.showErrorMessage(`errors in generateCommitMessage: ${error instanceof Error ? error.message : String(error)}`);
+                    vscode.window.showWarningMessage('git staged change is empty, using unstaged change');
                 }
-                progress.report({ increment: 100 });
-            });
-        } catch (error) {
-            vscode.window.showErrorMessage(`errors in generateCommitMessage: ${error instanceof Error ? error.message : String(error)}`);
+    
+                const prompt = this.app.prompts.replaceOnePlaceholders(this.app.prompts.CREATE_GIT_DIFF_COMMIT, "diff", diff);
+                vscode.window.withProgress({
+                    location: vscode.ProgressLocation.SourceControl,
+                    title: 'llama.vscode is generating a commit message...',
+                    cancellable: false
+                }, async (progress) => {
+                    try {
+                        // TODO stream output the commit message, need for llamaServer with stream output support
+                        const completion = await this.app.llamaServer.getChatCompletion(prompt)
+                        const commitMessage = completion?.choices[0]?.message.content
+    
+                        if (commitMessage) {
+                            repo.inputBox.value = commitMessage;
+                        } else {
+                            vscode.window.showErrorMessage('unexpected error for generating commit message is empty');
+                        }
+                    } catch (error) {
+                        vscode.window.showErrorMessage(`errors in generateCommitMessage: ${error instanceof Error ? error.message : String(error)}`);
+                    }
+                    progress.report({ increment: 100 });
+                });
+            } catch (error) {
+                vscode.window.showErrorMessage(`errors in generateCommitMessage: ${error instanceof Error ? error.message : String(error)}`);
+            }
         }
     }
 }


### PR DESCRIPTION
Despite github's messy diff here, the only changes are changing
const repo = git.repositories[0]; to for (const repo of git.repositories) {

and if (!diff || diff.trim() === '') {
return to continue

solves ggml-org#74