### PR TITLE
Add settings to disable the popups on startup for installing/upgrading llama.cpp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1390,6 +1390,16 @@
           "default": false,
           "description": "If true - starts the last used env on startup."
         },
+        "llama-vscode.ask_install_llamacpp": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, on starting VS Code - installation of llama.cpp will be suggested."
+        },
+        "llama-vscode.ask_upgrade_llamacpp_hours": {
+          "type": "number",
+          "default": 24,
+          "description": "How offen to ask the user to upgrade llama.cpp in hours."
+        },
         "llama-vscode.env_start_last_used_confirm": {
           "type": "boolean",
           "default": true,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -99,6 +99,8 @@ export class Configuration {
     envs_list = new Array();
     env_start_last_used = false;
     env_start_last_used_confirm = true;
+    ask_install_llamacpp = true;
+    ask_upgrade_llamacpp_hours = 24;
     ai_api_version = "v1";
     ai_model = "google/gemini-2.5-flash"
     agents_list = new Array();
@@ -246,6 +248,8 @@ export class Configuration {
         this.agents_list = config.get("agents_list")??new Array();
         this.env_start_last_used = Boolean(config.get<boolean>("env_start_last_used", true));
         this.env_start_last_used_confirm = Boolean(config.get<boolean>("env_start_last_used_confirm", true));
+        this.ask_install_llamacpp = Boolean(config.get<boolean>("ask_install_llamacpp", true));
+        this.ask_upgrade_llamacpp_hours = Number(config.get<number>("ask_upgrade_llamacpp_hours"));
     };
 
     getUiText = (uiText: string): string | undefined => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -799,8 +799,8 @@ export class Utils {
         }
     }
 
-    static is24HoursLater = (date1: Date, date2: Date): boolean => {
-        const twentyFourHoursInMs = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+    static isTimeToUpgrade = (date1: Date, date2: Date, interval: number): boolean => {
+        const twentyFourHoursInMs = interval  * 60 * 60 * 1000; // 24 hours in milliseconds
         const timeDifference = date2.getTime() - date1.getTime();
         
         return timeDifference >= twentyFourHoursInMs;


### PR DESCRIPTION
- Setting ask_install_llamacpp added to control if llama-vscode should ask the user to install llama.cpp
- Setting upgrade_llamacpp_hours added to control how often llama-vscode should ask the user to upgrade llama.cpp
- If the user cancels the llama.cpp installation on startup - llama-vscode suggests to disable the future popups for installation
- If the user cancels the llama.cpp upgrade on startup - llama-vscode suggests to disable the future popups for upgrade (sets upgrade_llamacpp_hours to more than 3 years)