### PR TITLE
fix: use correct function for loading last used env on startup

### DIFF
--- a/src/architect.ts
+++ b/src/architect.ts
@@ -35,10 +35,10 @@ export class Architect {
                                                                         this.app.envService.getEnvDetailsAsString(lastEnv) +
                                                                         "\n\n Do you want to continue?"
                                                                         );
-                    if (shouldSelect) this.app.envService.selectEnv(lastEnv, false);
+                    if (shouldSelect) this.app.envService.selectStartEnv(lastEnv, false);
                     if (dontAskAgain) this.app.configuration.updateConfigValue("env_start_last_used_confirm", false);
                 } else {
-                     this.app.envService.selectEnv(lastEnv, false);
+                     this.app.envService.selectStartEnv(lastEnv, false);
                 }
 
             }


### PR DESCRIPTION
This should fix a problem when llama.vscode started and failed to load the last used env due to using the wrong function.