### PR TITLE
Add AGENTS.md loading from workspace root

### DIFF
--- a/src/llama-agent.ts
+++ b/src/llama-agent.ts
@@ -56,7 +56,14 @@ export class LlamaAgent {
             }
         } else {
             const absolutePath = Utils.getAbsolutFilePath("llama-vscode-rules.md");
-            if (fs.existsSync(absolutePath)) projectContext += "  \n\nAdditional rules from the user: \n" + fs.readFileSync(absolutePath, "utf-8");
+            if (fs.existsSync(absolutePath)) {
+                projectContext += "  \n\nAdditional rules from the user: \n" + fs.readFileSync(absolutePath, "utf-8");
+            } else {
+                const agentsAbsolutePath = Utils.getAbsolutFilePath("AGENTS.md");
+                if (fs.existsSync(agentsAbsolutePath)) {
+                    projectContext += "  \n\nInstructions from " + agentsAbsolutePath + ": \n" + fs.readFileSync(agentsAbsolutePath, "utf-8");
+                }
+            }
         }
         this.messages = [
             {


### PR DESCRIPTION
- Only if `llama-vscode-rules.md` is not present to preserve existing functionality
- TODO: Implement nested AGENTS.md
- See: https://agents.md/

> [!NOTE]
> Only loads `AGENTS.md` from the workspace root. Does not handle nested `AGENTS.md`

At the time of this PR nested `AGENTS.md` was listed as *Experimental* for Copilot in vscode, so this limited implementation is most likely acceptable.