### PR TITLE
feat: add configurable debounce for inline completion requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1540,6 +1540,11 @@
           "default": true,
           "description": "If code completion should be triggered automatically (true) or only by pressing Ctrl+l."
         },
+        "llama-vscode.debounce_ms": {
+          "type": "number",
+          "default": 0,
+          "description": "Milliseconds to wait after the last keystroke before sending a completion request (0 = disabled). Useful on low-end hardware to avoid triggering inference on every keystroke."
+        },
         "llama-vscode.api_key": {
           "type": "string",
           "default": "",

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -30,6 +30,15 @@ export class Completion {
             return null;
         }
 
+        // Debounce: wait for the user to pause typing before hitting the backend
+        if (context.triggerKind == vscode.InlineCompletionTriggerKind.Automatic && this.app.configuration.debounce_ms > 0) {
+            await Utils.delay(this.app.configuration.debounce_ms);
+            if (token.isCancellationRequested) {
+                this.app.logger.addEventLog(group, "DEBOUNCE_CANCELLATION_RETURN", "")
+                return null;
+            }
+        }
+
         // Start only if the previous request is finiched
         while (this.isRequestInProgress) {
             await Utils.delay(this.app.configuration.DELAY_BEFORE_COMPL_REQUEST);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,6 +29,7 @@ export class Configuration {
     new_embeddings_model_host = "127.0.0.1"
     new_tools_model_host = "127.0.0.1"
     auto = true;
+    debounce_ms = 0;
     api_key = "";
     api_key_chat = "";
     api_key_tools = "";
@@ -194,6 +195,7 @@ export class Configuration {
         this.openai_client_model = String(config.get<string>("openai_client_model"));
         this.openai_prompt_template = String(config.get<string>("openai_prompt_template"));
         this.auto = Boolean(config.get<boolean>("auto"));
+        this.debounce_ms = Number(config.get<number>("debounce_ms"));
         this.api_key = String(config.get<string>("api_key"));
         this.api_key_chat = String(config.get<string>("api_key_chat"));
         this.api_key_tools = String(config.get<string>("api_key_tools"));


### PR DESCRIPTION
## Summary
Waits for the user to pause typing before sending a request to the server. Set to 0 (default) to disable.

## Changes
- Added debounce configuration option
- Implemented debounce logic in completion

## Motivation
Prevents rapid repeated triggers and improves inference stability.

Closes #161