### PR TITLE
fix: show 'extension is updated' notification only on actual version update

### DIFF
--- a/src/architect.ts
+++ b/src/architect.ts
@@ -26,6 +26,14 @@ export class Architect {
             this.app.menu.showHowToUseLlamaVscode();
             this.app.persistence.setGlobalValue("isFirstStart", false)
         }
+        const currentVersion = vscode.extensions.getExtension('ggml-org.llama-vscode')?.packageJSON?.version as string | undefined;
+        const storedVersion = this.app.persistence.getGlobalValue(PERSISTENCE_KEYS.EXTENSION_VERSION) as string | undefined;
+        if (currentVersion && storedVersion && currentVersion !== storedVersion) {
+            vscode.window.showInformationMessage(this.app.configuration.getUiText(`llama-vscode extension is updated.`) ?? "");
+        }
+        if (currentVersion) {
+            this.app.persistence.setGlobalValue(PERSISTENCE_KEYS.EXTENSION_VERSION, currentVersion);
+        }
         await this.installUpgradeLlamaCpp(isFirstStart);
         if (this.app.configuration.env_start_last_used){
             let lastEnv = this.app.persistence.getValue("selectedEnv")
@@ -70,7 +78,6 @@ export class Architect {
             if (this.app.configuration.isRagConfigChanged(event)) this.init();
             if (this.app.configuration.isToolChanged(event)) this.app.tools.init();
             if (this.app.configuration.isEnvViewSettingChanged(event)) this.app.llamaWebviewProvider.updateLlamaView();
-            vscode.window.showInformationMessage(this.app.configuration.getUiText(`llama-vscode extension is updated.`)??"");
         });
         context.subscriptions.push(configurationChangeDisp);
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -253,6 +253,7 @@ export const PERSISTENCE_KEYS = {
   SELECTED_CHAT: 'selectedChat' as const,
   SELECTED_AGENT: 'selectedAgent' as const,
   SELECTED_ENV: 'selectedEnv' as const,
+  EXTENSION_VERSION: 'extensionVersion' as const,
 } as const;
 
 export const SETTING_NAME_FOR_LIST = {


### PR DESCRIPTION
## Problem

The notification `"llama-vscode extension is updated."` fires on every VS Code startup and whenever any VS Code setting is changed, even if the setting is unrelated to llama.vscode.
This is because it is placed unconditionally inside `onDidChangeConfiguration`, VS Code triggers during extension activation (startup) and on any config change.

## Fix

- **`src/architect.ts`**: Removed the `showInformationMessage` call from `setOnChangeConfiguration`. Added a version-check in `init()`: reads the current extension, compares it to the previously stored version in `globalState`, and shows the notification only when the version has actually changed. Skips the notification on first install. Persists the new version after each check.
- **`src/constants.ts`**: Added `EXTENSION_VERSION` key to `PERSISTENCE_KEYS`.

## Result

The notification now appears exactly once, immediately after the extension is updated to a new version. Stops the notification from appearing on startup or config changes.

Fixes #165