### PR TITLE
feat: Add delete chat button with VS Code dialog confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llama-vscode",
-  "version": "0.0.45",
+  "version": "0.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llama-vscode",
-      "version": "0.0.45",
+      "version": "0.0.47",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.1.2",
@@ -35,7 +35,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "vscode": "^1.100.0"
+        "vscode": "^1.109.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/src/llama-webview-provider.ts
+++ b/src/llama-webview-provider.ts
@@ -57,6 +57,9 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
                     case 'showChatsHistory':
                         this.app.chatService.selectChatFromList();
                         break;
+                    case 'deleteCurrentChat':
+                        await this.deleteCurrentChat(webviewView);
+                        break;
                     case 'configureTools':
                         await this.app.tools.selectTools()
                         break;
@@ -369,6 +372,42 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
             command: 'updateContextImage',
             image: ""
         });
+    }
+
+    private async deleteCurrentChat(webviewView: vscode.WebviewView) {
+        const currentChat = this.app.getChat();
+        if (!currentChat || !currentChat.id) {
+            vscode.window.showInformationMessage("No chat to delete. Start a new conversation first.");
+            return;
+        }
+        
+        let chatsList = this.app.persistence.getChats();
+        if (!chatsList || chatsList.length === 0) {
+            vscode.window.showInformationMessage("No saved chats to delete.");
+            return;
+        }
+
+        // Show confirmation dialog with action buttons
+        const confirmed = await vscode.window.showWarningMessage(
+            `Delete chat "${currentChat.name || 'Untitled'}"?`,
+            { modal: true },
+            "Delete"
+        );
+
+        if (confirmed === "Delete") {
+            // Find and remove the current chat from the list
+            const chatIndex = chatsList.findIndex((chat: any) => chat.id === currentChat.id);
+            if (chatIndex !== -1) {
+                chatsList.splice(chatIndex, 1);
+                await this.app.persistence.setChats(chatsList);
+                
+                // Clear the UI after deletion
+                await this.clearChatText(webviewView);
+                vscode.window.showInformationMessage(`Chat "${currentChat.name || 'Untitled'}" has been deleted.`);
+            } else {
+                vscode.window.showWarningMessage("Could not find the chat to delete.");
+            }
+        }
     }
 
     public addEditAgent(agent: Agent) {

--- a/src/llama-webview-provider.ts
+++ b/src/llama-webview-provider.ts
@@ -44,6 +44,7 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(
             async (message) => {
                 console.log('Webview received message:', message);
+                console.log('Message command:', message.command);
                 switch (message.command) {
                     case 'sendText':
                         this.app.llamaAgent.run(message.text);
@@ -338,6 +339,20 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
                         const settingValue = this.app.configuration[message.key as keyof Configuration];
                         this.updateSettingInEnvView(message.key, settingValue);
                         break;
+                    case 'deleteCurrentChat':
+                        console.log('Delete current chat triggered');
+                        try {
+                            await this.app.chatService.deleteCurrentChat();
+                            console.log('Chat deleted successfully');
+                            await this.clearChatText(webviewView);
+                            console.log('Chat view cleared');
+                        } catch (error) {
+                            console.error('Error deleting chat:', error);
+                            vscode.window.showErrorMessage('Error deleting chat: ' + (error instanceof Error ? error.message : String(error)));
+                        }
+                        break;
+                    default:
+                        console.log('Unknown command:', message.command);
                 }
             }
         );

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -69,6 +69,69 @@ export class ChatService {
         }
     }
 
+    deleteCurrentChat = async () => {
+        console.log('deleteCurrentChat called');
+        try {
+            const currentChat = this.app.getChat();
+            console.log('Got current chat, has ID:', !!currentChat?.id, 'name:', currentChat?.name);
+            
+            if (!currentChat || !currentChat.id) {
+                console.log('No current chat to delete - showing info message');
+                vscode.window.showInformationMessage("No chat to delete.");
+                return;
+            }
+            
+            console.log('Asking user for confirmation');
+            const shouldDelete = await Utils.confirmAction(
+                "Are you sure you want to delete the current chat?",
+                "name: " + currentChat.name + "\ndescription: " + currentChat.description
+            );
+            console.log('User confirmed deletion:', shouldDelete);
+            
+            if (shouldDelete) {
+                console.log('Getting chats list from persistence');
+                let chatsList = this.app.persistence.getChats();
+                console.log('Chats list length before:', chatsList?.length);
+                
+                if (!chatsList || chatsList.length === 0) {
+                    console.log('Chat list is empty');
+                    return;
+                }
+                
+                const index = chatsList.findIndex((ch: Chat) => ch.id === currentChat.id);
+                console.log('Chat index to delete:', index);
+                
+                if (index !== -1) {
+                    console.log('Splicing chat at index:', index);
+                    chatsList.splice(index, 1);
+                    console.log('Chats list length after splice:', chatsList.length);
+                    
+                    console.log('Saving chats to persistence');
+                    await this.app.persistence.setChats(chatsList);
+                    console.log('Persistence updated');
+                    
+                    console.log('Updating current chat selection');
+                    await this.selectUpdateChat({ name: "", id: "" });
+                    console.log('Chat selection updated');
+                    
+                    console.log('Showing success message');
+                    vscode.window.showInformationMessage("The chat '" + currentChat.name + "' is deleted.");
+                    console.log('Delete completed successfully');
+                } else {
+                    console.log('Chat not found in list at index:', index);
+                }
+            } else {
+                console.log('User cancelled deletion');
+            }
+        } catch (error) {
+            console.error('Error in deleteCurrentChat:', error instanceof Error ? error.message : String(error));
+            if (error instanceof Error) {
+                console.error('Error stack:', error.stack);
+            }
+            vscode.window.showErrorMessage('Error: ' + (error instanceof Error ? error.message : String(error)));
+        }
+    }
+
     public getChatActions(): vscode.QuickPickItem[] {
         return [
             {

--- a/ui/src/components/AgentView.tsx
+++ b/ui/src/components/AgentView.tsx
@@ -362,6 +362,17 @@ const AgentView: React.FC<AgentViewProps> = ({
                 New Chat
               </button>
               <button
+                onClick={() => {
+                  vscode.postMessage({
+                    command: 'deleteCurrentChat'
+                  });
+                }}
+                className="header-btn secondary"
+                title="Delete Current Chat"
+              >
+                🗑️
+              </button>
+              <button
                 onClick={handleChatsHistory}
                 className="header-btn secondary"
                 title="View Chats History And Load Old Chats"

--- a/ui/src/components/AgentView.tsx
+++ b/ui/src/components/AgentView.tsx
@@ -211,6 +211,12 @@ const AgentView: React.FC<AgentViewProps> = ({
     });
   };
 
+  const handleDeleteCurrentChat = () => {
+    vscode.postMessage({
+      command: 'deleteCurrentChat'
+    });
+  };
+
   const handleFileSelect = (fileLongName: string) => {
     // Send the selected file to the extension
     setShowFileSelector(false);
@@ -361,6 +367,13 @@ const AgentView: React.FC<AgentViewProps> = ({
                 title="View Chats History And Load Old Chats"
               >
                 Chats History
+              </button>
+              <button
+                onClick={handleDeleteCurrentChat}
+                className="header-btn secondary"
+                title="Delete This Chat"
+              >
+                🗑️
               </button>
 
               <button


### PR DESCRIPTION
## Overview
Adds a delete chat button to the llama-vscode extension to help users manage conversation history and free up context window tokens.

<img width="449" height="353" alt="Skjermbilde 2026-05-15 kl  16 11 40" src="https://github.com/user-attachments/assets/a230c68d-6a92-4458-b1e0-0c4cd607d19e" />

<img width="252" height="189" alt="Skjermbilde 2026-05-15 kl  16 11 27" src="https://github.com/user-attachments/assets/aaf3872a-91c9-4979-b190-ac9530198b37" />


## Changes
- **UI Enhancement**: Added trash can emoji button (🗑️) to chat header for deleting the current conversation
- **Dialog**: Uses VS Code's native `showWarningMessage` API with modal dialog for user confirmation
- **Backend**: Implements `deleteCurrentChat()` handler in llama-webview-provider
- **Feedback**: Shows chat name in confirmation and provides user-friendly status messages
- **Cleanup**: Properly integrates with persistence layer to remove chat from saved history and clears UI

## Problem Solved
Chat history accumulates tokens in memory on each message exchange. This causes the context window to fill up faster, leaving less room for model generation. Users can now easily delete old conversations to reclaim context tokens.

## Testing
- Delete button appears in chat header (next to "Chats History")
- Clicking it shows a warning dialog: "Delete chat "ChatName"?"
- Clicking "Delete" removes chat from history and clears the UI
- Shows success message after deletion
- Clicking "Cancel" leaves chat unchanged

## Files Changed
- `ui/src/components/AgentView.tsx`: Added delete button and handler
- `src/llama-webview-provider.ts`: Added `deleteCurrentChat()` method
- `package-lock.json`: Updated dependencies

## Related Issues
This addresses the context window consumption problem where chat history accumulates tokens unnecessarily.