### PR TITLE
Fix VS Code Chat context window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llama-vscode",
-  "version": "0.0.45",
+  "version": "0.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llama-vscode",
-      "version": "0.0.45",
+      "version": "0.0.47",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.1.2",
@@ -35,7 +35,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "vscode": "^1.100.0"
+        "vscode": "^1.109.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -2179,6 +2179,16 @@
           "default": 64000,
           "description": "Max number of tokens per chat (1 token ~4 chars). If the chat is longer, the initial part will be summarized. This is approximate - the detection is by counting the chars in a chat (assuming 1 token is 4 chars)."
         },
+        "llama-vscode.lm_max_input_tokens": {
+          "type": "number",
+          "default": 0,
+          "description": "Max input tokens advertised to VS Code for models provided through the Copilot model list. Set to 0 to auto-detect from provider metadata or llama.cpp runtime properties when available. Set a positive value to force an override."
+        },
+        "llama-vscode.lm_max_output_tokens": {
+          "type": "number",
+          "default": 0,
+          "description": "Max output tokens advertised to VS Code for models provided through the Copilot model list. Set to 0 to auto-detect from provider metadata when available and otherwise use the extension default. Set a positive value to force an override. The advertised output limit is also used as the max_tokens request cap for chat completions from the VS Code LM provider."
+        },
         "llama-vscode.chats_summarize_old_msgs": {
           "type": "boolean",
           "default": false,

--- a/src/application.ts
+++ b/src/application.ts
@@ -225,6 +225,12 @@ export class Application {
                 this.selectedToolsModel = model??Application.emptyModel;
                 break;
         }
+        if (type === ModelType.Tools) {
+            // VS Code caches LM capabilities for the selected provider/model entry.
+            // Refresh them immediately when the tools model changes so the live picker
+            // does not keep showing stale fallback limits such as the old 12K budget.
+            this.llamaChatModelProvider.notifyModelsChanged();
+        }
         this.llamaWebviewProvider.updateLlamaView();
     }
 

--- a/src/architect.ts
+++ b/src/architect.ts
@@ -222,7 +222,9 @@ export class Architect {
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration('llama-vscode.endpoint_chat')
                 || event.affectsConfiguration('llama-vscode.endpoint_tools')
-                || event.affectsConfiguration('llama-vscode.ai_api_version')) {
+                || event.affectsConfiguration('llama-vscode.ai_api_version')
+                || event.affectsConfiguration('llama-vscode.lm_max_input_tokens')
+                || event.affectsConfiguration('llama-vscode.lm_max_output_tokens')) {
                 this.app.llamaChatModelProvider.notifyModelsChanged();
             }
         }));

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -103,6 +103,8 @@ export class Configuration {
     chats_max_tokens = 64000;
     chats_summarize_old_msgs = false;
     chats_msgs_keep = 50
+    lm_max_input_tokens = 0;
+    lm_max_output_tokens = 0;
     max_parallel_completions = 3
     completion_models_list = new Array();
     embeddings_models_list = new Array();
@@ -256,6 +258,8 @@ export class Configuration {
         this.max_parallel_completions = Number(config.get<number>("max_parallel_completions"));
         this.chats_summarize_old_msgs = Boolean(config.get<boolean>("chats_summarize_old_msgs"));
         this.chats_msgs_keep = Number(config.get<number>("chats_msgs_keep"));
+        this.lm_max_input_tokens = Number(config.get<number>("lm_max_input_tokens"));
+        this.lm_max_output_tokens = Number(config.get<number>("lm_max_output_tokens"));
         this.skills_folder = String(config.get<string>("skills_folder"));
         this.language = String(config.get<string>("language"));
         this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];

--- a/src/language-model-token-limits.ts
+++ b/src/language-model-token-limits.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_MAX_INPUT_TOKENS = 8192;
 export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 export const DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS = 256;
+export const DEFAULT_MAX_OUTPUT_TOKENS_CONTEXT_DIVISOR = 4;
 
 // Fallback-only heuristic for degraded mode.
 //
@@ -129,10 +130,7 @@ export function extractRuntimeContextSize(propsResponse: unknown): number | unde
 export function resolveRequestMaxOutputTokens(
     options: ResolveRequestMaxOutputTokensOptions = {}
 ): number {
-    const requestedMaxOutputTokens =
-        getPositiveInteger(options.maxOutputTokens)
-        ?? options.defaultMaxOutputTokens
-        ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    const requestedMaxOutputTokens = resolveBoundedMaxOutputTokens(options);
     const maxInputTokens = getPositiveInteger(options.maxInputTokens);
     const promptTokenEstimate = getPositiveInteger(options.promptTokenEstimate) ?? 0;
     const contextSafetyMarginTokens =
@@ -148,6 +146,25 @@ export function resolveRequestMaxOutputTokens(
     }
 
     return Math.max(1, Math.min(requestedMaxOutputTokens, remainingContextTokens));
+}
+
+export function resolveBoundedMaxOutputTokens(
+    options: Pick<ResolveRequestMaxOutputTokensOptions, 'maxInputTokens' | 'maxOutputTokens' | 'defaultMaxOutputTokens'> = {}
+): number {
+    const requestedMaxOutputTokens =
+        getPositiveInteger(options.maxOutputTokens)
+        ?? options.defaultMaxOutputTokens
+        ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    const maxInputTokens = getPositiveInteger(options.maxInputTokens);
+
+    if (maxInputTokens === undefined) {
+        return requestedMaxOutputTokens;
+    }
+
+    return Math.max(
+        1,
+        Math.min(requestedMaxOutputTokens, Math.floor(maxInputTokens / DEFAULT_MAX_OUTPUT_TOKENS_CONTEXT_DIVISOR))
+    );
 }
 
 function extractModelTokenLimit(

--- a/src/language-model-token-limits.ts
+++ b/src/language-model-token-limits.ts
@@ -1,0 +1,220 @@
+export const DEFAULT_MAX_INPUT_TOKENS = 8192;
+export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+export const DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS = 256;
+
+// Fallback-only heuristic for degraded mode.
+//
+// The preferred counting path in llama-vscode is to ask llama.cpp to apply the
+// active chat template and tokenize the exact prompt via the server. This
+// helper exists only for cases where that authoritative path is unavailable,
+// fails transiently, or is too early in startup to rely on. It should not be
+// treated as the normal or authoritative way to count tokens.
+export function estimateTokenCount(value: unknown): number {
+    const serializedValue =
+        typeof value === 'string'
+            ? value
+            : JSON.stringify(value ?? '');
+
+    if (!serializedValue) {
+        return 0;
+    }
+
+    return Math.ceil(serializedValue.length / 4);
+}
+
+const INPUT_TOKEN_FIELDS = [
+    'max_input_tokens',
+    'input_token_limit',
+    'prompt_token_limit',
+    'max_prompt_tokens',
+    'context_length',
+    'context_window',
+    'max_context_length',
+    'max_sequence_length',
+    'max_position_embeddings',
+    'n_ctx',
+    'n_ctx_train',
+] as const;
+
+const OUTPUT_TOKEN_FIELDS = [
+    'max_output_tokens',
+    'output_token_limit',
+    'completion_token_limit',
+    'max_completion_tokens',
+    'max_generated_tokens',
+] as const;
+
+const NESTED_METADATA_FIELDS = ['meta', 'metadata', 'limits', 'top_provider'] as const;
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface OpenAICompatibleModel extends UnknownRecord {
+    id: string;
+    object?: string;
+}
+
+export function isLikelyLlamaCppProvider(models: OpenAICompatibleModel[]): boolean {
+    return models.some((model) => {
+        const ownedBy = typeof model.owned_by === 'string' ? model.owned_by.toLowerCase() : '';
+        return ownedBy === 'llamacpp' || asRecord(model.meta) !== undefined;
+    });
+}
+
+export function buildRuntimePropsUrl(endpoint: string, modelId?: string): string {
+    const normalizedEndpoint = endpoint.replace(/\/+$/, '');
+    if (!modelId) {
+        return `${normalizedEndpoint}/props`;
+    }
+
+    const params = new URLSearchParams({
+        model: modelId,
+        autoload: 'false',
+    });
+    return `${normalizedEndpoint}/props?${params.toString()}`;
+}
+
+export interface ResolvedModelTokenLimits {
+    maxInputTokens: number;
+    maxOutputTokens: number;
+}
+
+interface ResolveRequestMaxOutputTokensOptions {
+    maxInputTokens?: number;
+    maxOutputTokens?: number;
+    promptTokenEstimate?: number;
+    defaultMaxOutputTokens?: number;
+    contextSafetyMarginTokens?: number;
+}
+
+interface ResolveModelTokenLimitsOptions {
+    configuredMaxInputTokens?: number;
+    configuredMaxOutputTokens?: number;
+    runtimeContextSize?: number;
+    defaultMaxInputTokens?: number;
+    defaultMaxOutputTokens?: number;
+}
+
+export function resolveModelTokenLimits(
+    model: OpenAICompatibleModel,
+    options: ResolveModelTokenLimitsOptions = {}
+): ResolvedModelTokenLimits {
+    const configuredMaxInputTokens = getPositiveInteger(options.configuredMaxInputTokens);
+    const configuredMaxOutputTokens = getPositiveInteger(options.configuredMaxOutputTokens);
+    const detectedMaxInputTokens =
+        getPositiveInteger(options.runtimeContextSize) ?? extractModelTokenLimit(model, INPUT_TOKEN_FIELDS);
+    const detectedMaxOutputTokens = extractModelTokenLimit(model, OUTPUT_TOKEN_FIELDS);
+    const llamaCppOutputFallback = usesInputLimitAsOutputFallback(model) ? detectedMaxInputTokens : undefined;
+
+    return {
+        maxInputTokens:
+            configuredMaxInputTokens
+            ?? detectedMaxInputTokens
+            ?? options.defaultMaxInputTokens
+            ?? DEFAULT_MAX_INPUT_TOKENS,
+        maxOutputTokens:
+            configuredMaxOutputTokens
+            ?? detectedMaxOutputTokens
+            ?? llamaCppOutputFallback
+            ?? options.defaultMaxOutputTokens
+            ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    };
+}
+
+export function extractRuntimeContextSize(propsResponse: unknown): number | undefined {
+    const props = asRecord(propsResponse);
+    const defaultGenerationSettings = asRecord(props?.default_generation_settings);
+    return getPositiveInteger(defaultGenerationSettings?.n_ctx);
+}
+
+export function resolveRequestMaxOutputTokens(
+    options: ResolveRequestMaxOutputTokensOptions = {}
+): number {
+    const requestedMaxOutputTokens =
+        getPositiveInteger(options.maxOutputTokens)
+        ?? options.defaultMaxOutputTokens
+        ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    const maxInputTokens = getPositiveInteger(options.maxInputTokens);
+    const promptTokenEstimate = getPositiveInteger(options.promptTokenEstimate) ?? 0;
+    const contextSafetyMarginTokens =
+        getPositiveInteger(options.contextSafetyMarginTokens) ?? DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS;
+
+    if (maxInputTokens === undefined) {
+        return requestedMaxOutputTokens;
+    }
+
+    const remainingContextTokens = maxInputTokens - promptTokenEstimate - contextSafetyMarginTokens;
+    if (remainingContextTokens <= 0) {
+        return 1;
+    }
+
+    return Math.max(1, Math.min(requestedMaxOutputTokens, remainingContextTokens));
+}
+
+function extractModelTokenLimit(
+    model: OpenAICompatibleModel,
+    fieldNames: readonly string[]
+): number | undefined {
+    for (const candidate of getCandidateRecords(model)) {
+        const tokenLimit = getFirstPositiveInteger(candidate, fieldNames);
+        if (tokenLimit !== undefined) {
+            return tokenLimit;
+        }
+    }
+
+    return undefined;
+}
+
+function getCandidateRecords(model: OpenAICompatibleModel): UnknownRecord[] {
+    const candidates: UnknownRecord[] = [model];
+
+    for (const fieldName of NESTED_METADATA_FIELDS) {
+        const nestedRecord = asRecord(model[fieldName]);
+        if (nestedRecord) {
+            candidates.push(nestedRecord);
+        }
+    }
+
+    return candidates;
+}
+
+function getFirstPositiveInteger(
+    source: UnknownRecord,
+    fieldNames: readonly string[]
+): number | undefined {
+    for (const fieldName of fieldNames) {
+        const value = getPositiveInteger(source[fieldName]);
+        if (value !== undefined) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+
+    return value as UnknownRecord;
+}
+
+function usesInputLimitAsOutputFallback(model: OpenAICompatibleModel): boolean {
+    const ownedBy = typeof model.owned_by === 'string' ? model.owned_by.toLowerCase() : '';
+    return ownedBy === 'llamacpp' || asRecord(model.meta) !== undefined;
+}
+
+function getPositiveInteger(value: unknown): number | undefined {
+    const numberValue =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string' && value.trim() !== ''
+                ? Number(value)
+                : undefined;
+
+    if (numberValue === undefined || !Number.isFinite(numberValue) || numberValue <= 0) {
+        return undefined;
+    }
+
+    return Math.floor(numberValue);
+}

--- a/src/language-model-token-limits.ts
+++ b/src/language-model-token-limits.ts
@@ -79,6 +79,11 @@ export interface ResolvedModelTokenLimits {
     maxOutputTokens: number;
 }
 
+export interface PublishedModelTokenLimits {
+	maxInputTokens: number;
+	maxOutputTokens: number;
+}
+
 interface ResolveRequestMaxOutputTokensOptions {
     maxInputTokens?: number;
     maxOutputTokens?: number;
@@ -118,6 +123,28 @@ export function resolveModelTokenLimits(
             ?? llamaCppOutputFallback
             ?? options.defaultMaxOutputTokens
             ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    };
+}
+
+export function resolvePublishedModelTokenLimits(
+    model: OpenAICompatibleModel,
+    options: ResolveModelTokenLimitsOptions = {}
+): PublishedModelTokenLimits {
+    const resolvedLimits = resolveModelTokenLimits(model, options);
+
+    if (!usesInputLimitAsOutputFallback(model)) {
+        return resolvedLimits;
+    }
+
+    const publishedMaxOutputTokens = resolveBoundedMaxOutputTokens({
+        maxInputTokens: resolvedLimits.maxInputTokens,
+        maxOutputTokens: resolvedLimits.maxOutputTokens,
+        defaultMaxOutputTokens: options.defaultMaxOutputTokens,
+    });
+
+    return {
+        maxInputTokens: Math.max(1, resolvedLimits.maxInputTokens - publishedMaxOutputTokens),
+        maxOutputTokens: publishedMaxOutputTokens,
     };
 }
 

--- a/src/llama-agent.ts
+++ b/src/llama-agent.ts
@@ -7,6 +7,7 @@ import { Plugin } from './plugin';
 import * as fs from 'fs';
 import { SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
 import path from "path";
+import { DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS } from './language-model-token-limits';
 
 
 interface Frontmatter {
@@ -167,9 +168,9 @@ export class LlamaAgent {
         await this.askAgent(query, agentCommand);
     }
 
-    private async summarize(): Promise<void> {
+    private async summarize(): Promise<boolean> {
         if (this.messages.length <= this.app.configuration.chats_msgs_keep) {
-            return; // Not enough messages to summarize
+            return false; // Not enough messages to summarize
         }
 
         // Preserve system messages and recent messages
@@ -181,7 +182,7 @@ export class LlamaAgent {
         );
 
         if (oldMessages.length === 0) {
-            return; // Nothing to summarize
+            return false; // Nothing to summarize
         }
 
         try {
@@ -196,11 +197,49 @@ export class LlamaAgent {
                 },
                 ...recentMessages
             ];
+            return true;
 
         } catch (error) {
             console.error('Failed to generate summary:', error);
             // Fallback: just keep recent messages and remove older ones
             this.messages = [...systemMessages, ...recentMessages];
+            return true;
+        }
+    }
+
+    private async summarizeToFitCurrentBudget(imagePath = ""): Promise<boolean> {
+        const tokenLimits = await this.app.llamaServer.getToolsModelTokenLimits();
+        const reservedOutputTokens = Math.max(
+            1024,
+            Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS)
+        );
+        const maxPromptTokens = Math.max(
+            1,
+            tokenLimits.maxInputTokens - reservedOutputTokens - DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS
+        );
+
+        let summarizedAny = false;
+        while (true) {
+            const promptTokens = await this.app.llamaServer.countToolsPromptTokens(this.messages, imagePath);
+            this.app.logger.addEventLog(
+                'AGENT',
+                'BUDGET_CHECK',
+                `prompt_tokens=${promptTokens ?? 'unknown'} | max_prompt_tokens=${maxPromptTokens} | messages=${this.messages.length}`
+            );
+            if (promptTokens === undefined || promptTokens <= maxPromptTokens) {
+                return summarizedAny;
+            }
+
+            if (!this.app.configuration.chats_summarize_old_msgs) {
+                return summarizedAny;
+            }
+
+            const summarized = await this.summarize();
+            if (!summarized) {
+                return summarizedAny;
+            }
+            this.app.logger.addEventLog('AGENT', 'BUDGET_SUMMARIZE', `messages=${this.messages.length}`);
+            summarizedAny = true;
         }
     }
 
@@ -224,11 +263,6 @@ export class LlamaAgent {
                 return "Tools model is not selected"
             }
             
-            if (this.app.configuration.chats_summarize_old_msgs 
-                && JSON.stringify(this.messages).length > this.app.configuration.chats_max_tokens*4) {
-                this.summarize();
-            }
-
             // Get the skills
             const skillsFolder = this.app.configuration.skills_folder || Utils.getWorkspaceFolder() + "/" + "skills"
             let skillsDesc = this.getSkillsDesc(skillsFolder)
@@ -300,6 +334,7 @@ export class LlamaAgent {
                         currentPlan += fs.readFileSync(todoFile, "utf-8")
                         this.messages.push({"role": "user", "content": goal + "\n\n" + currentPlan})                   
                     }
+                    await this.summarizeToFitCurrentBudget(this.contextImage);
                     let streamed = "";
                     let data:any = await this.app.llamaServer.getAgentCompletion(this.messages, false, (delta: string) => {
                         streamed += delta;
@@ -308,15 +343,42 @@ export class LlamaAgent {
                     }, this.abortController?.signal, !this.sentContextImages.includes(this.contextImage)? this.contextImage : "");
                     if (this.contextImage) this.sentContextImages.push(this.contextImage)
                     if (!data) {
+                        this.app.logger.addEventLog('AGENT', 'NO_RESPONSE', `iteration=${iterationsCount}`);
                         this.logText += "No response from AI" + "  \n"
                         this.app.llamaWebviewProvider.logInUi(this.logText);
                         this.app.llamaWebviewProvider.setState("AI not responding")
                         return "No response from AI";
                     }
+                    if (data.error?.type === "exceed_context_size_error") {
+                        this.app.logger.addEventLog(
+                            'AGENT',
+                            'CONTEXT_ERROR',
+                            `iteration=${iterationsCount} | prompt_tokens=${data.error.n_prompt_tokens ?? 'unknown'} | n_ctx=${data.error.n_ctx ?? 'unknown'}`
+                        );
+                        this.logText += "Error: " + data.error.message + "  \n";
+                        if (typeof data.error.n_prompt_tokens === 'number' && typeof data.error.n_ctx === 'number') {
+                            this.logText += `Prompt tokens: ${data.error.n_prompt_tokens}, context window: ${data.error.n_ctx}  \n`;
+                        }
+                        this.app.llamaWebviewProvider.logInUi(this.logText);
+
+                        const summarized = await this.summarizeToFitCurrentBudget(this.contextImage);
+                        if (summarized) {
+                            this.app.logger.addEventLog('AGENT', 'CONTEXT_RETRY', `iteration=${iterationsCount}`);
+                            continue;
+                        }
+
+                        this.app.llamaWebviewProvider.setState("Context limit exceeded")
+                        return data.error.message;
+                    }
+
                     finishReason = data.choices[0].finish_reason;
                     response = data.choices[0].message.content;
                     if (!streamed && response) {
                         this.logText += response + "  \n";
+                    }
+                    if (data.truncated) {
+                        this.app.logger.addEventLog('AGENT', 'TRUNCATED_RESPONSE', `iteration=${iterationsCount} | finish_reason=${finishReason ?? 'unknown'}`);
+                        this.logText += "  \nWarning: response was truncated by the context window.  \n";
                     }
                     this.logText += "  \nTotal iterations: " + iterationsCount + "  \n"
                     this.app.llamaWebviewProvider.logInUi(this.logText);

--- a/src/llama-agent.ts
+++ b/src/llama-agent.ts
@@ -7,7 +7,7 @@ import { Plugin } from './plugin';
 import * as fs from 'fs';
 import { SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
 import path from "path";
-import { DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS } from './language-model-token-limits';
+import { DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS, resolveBoundedMaxOutputTokens } from './language-model-token-limits';
 
 
 interface Frontmatter {
@@ -209,10 +209,11 @@ export class LlamaAgent {
 
     private async summarizeToFitCurrentBudget(imagePath = ""): Promise<boolean> {
         const tokenLimits = await this.app.llamaServer.getToolsModelTokenLimits();
-        const reservedOutputTokens = Math.max(
-            1024,
-            Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS)
-        );
+        const reservedOutputTokens = Math.max(1024, resolveBoundedMaxOutputTokens({
+            maxInputTokens: tokenLimits.maxInputTokens,
+            maxOutputTokens: tokenLimits.maxOutputTokens,
+            defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        }));
         const maxPromptTokens = Math.max(
             1,
             tokenLimits.maxInputTokens - reservedOutputTokens - DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -11,6 +11,7 @@ import {
     isLikelyLlamaCppProvider,
     OpenAICompatibleModel,
     resolveModelTokenLimits,
+    resolvePublishedModelTokenLimits,
     resolveBoundedMaxOutputTokens,
     resolveRequestMaxOutputTokens,
 } from './language-model-token-limits';
@@ -97,7 +98,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             const runtimeContextSizes = await this.getRuntimeContextSizes(endpoint, response.data.data, requestConfig);
 
             return response.data.data.map((model) => {
-                const tokenLimits = resolveModelTokenLimits(model, {
+                const tokenLimits = resolvePublishedModelTokenLimits(model, {
                     configuredMaxInputTokens: this.app.configuration.lm_max_input_tokens,
                     configuredMaxOutputTokens: this.app.configuration.lm_max_output_tokens,
                     runtimeContextSize: runtimeContextSizes.get(model.id),

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -259,11 +259,123 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             const readable = streamResponse.data;
             let buffer = '';
             const toolCalls: { id: string; name: string; arguments: string }[] = [];
+            let settled = false;
+            let reportedResponsePart = false;
+
+            const resolveOnce = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                resolve();
+            };
+
+            const rejectOnce = (error: Error) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                reject(error);
+            };
+
+            const reportTextPart = (content: string) => {
+                if (!content) {
+                    return;
+                }
+
+                reportedResponsePart = true;
+                progress.report(new vscode.LanguageModelTextPart(content));
+            };
+
+            const rejectStreamError = (apiError: ProviderApiError, rawError: unknown) => {
+                this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, apiError, trace, `model=${model.id}`);
+                rejectOnce(this.toProviderError(apiError, rawError));
+                readable.removeAllListeners();
+            };
+
+            const processPayload = (payload: string): boolean => {
+                if (payload === '[DONE]') {
+                    finalize();
+                    readable.removeAllListeners();
+                    return true;
+                }
+
+                try {
+                    const json = JSON.parse(payload);
+                    if (json?.error) {
+                        rejectStreamError(this.normalizeProviderApiError(json.error), json.error);
+                        return true;
+                    }
+
+                    const choice = json.choices?.[0];
+                    if (!choice) {
+                        return false;
+                    }
+
+                    if (choice.error) {
+                        rejectStreamError(this.normalizeProviderApiError(choice.error), choice.error);
+                        return true;
+                    }
+
+                    const delta = choice.delta ?? {};
+                    if (typeof delta.content === 'string') {
+                        reportTextPart(delta.content);
+                    }
+
+                    if (Array.isArray(delta.tool_calls)) {
+                        for (const tc of delta.tool_calls) {
+                            const idx: number = typeof tc.index === 'number' ? tc.index : 0;
+                            if (!toolCalls[idx]) {
+                                toolCalls[idx] = { id: '', name: '', arguments: '' };
+                            }
+                            if (tc.id) {
+                                toolCalls[idx].id = tc.id;
+                            }
+                            if (tc.function?.name) {
+                                toolCalls[idx].name = tc.function.name;
+                            }
+                            if (tc.function?.arguments) {
+                                toolCalls[idx].arguments += tc.function.arguments;
+                            }
+                        }
+                    }
+                } catch {
+                    // Skip malformed SSE chunks
+                }
+
+                return false;
+            };
+
+            const processBufferedLines = (chunkText: string, flushPartialLine = false): boolean => {
+                buffer += chunkText;
+                const lines = buffer.split(/\r?\n/);
+
+                if (!flushPartialLine) {
+                    buffer = lines.pop() ?? '';
+                } else {
+                    buffer = '';
+                }
+
+                for (const line of lines) {
+                    const trimmed = line.trim();
+                    if (!trimmed || !trimmed.startsWith('data:')) {
+                        continue;
+                    }
+
+                    const payload = trimmed.slice(5).trim();
+                    if (processPayload(payload)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
 
             const finalize = () => {
                 for (const tc of toolCalls) {
                     if (tc.id && tc.name) {
                         try {
+                            reportedResponsePart = true;
                             progress.report(
                                 new vscode.LanguageModelToolCallPart(tc.id, tc.name, JSON.parse(tc.arguments || '{}'))
                             );
@@ -272,84 +384,50 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         }
                     }
                 }
-                resolve();
+
+                if (!reportedResponsePart) {
+                    this.app.logger.addEventLog(
+                        'API',
+                        'CHAT_COMPLETIONS_EMPTY_RESPONSE',
+                        [
+                            `request_id=${trace.requestId}`,
+                            `caller=${trace.caller}`,
+                            trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
+                            typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
+                            `model=${model.id}`,
+                        ].filter(Boolean).join(' | ')
+                    );
+
+                    const error = new Error('The model returned an empty response.') as Error & { cause?: unknown };
+                    error.name = 'LanguageModelProviderError';
+                    rejectOnce(error);
+                    return;
+                }
+
+                resolveOnce();
             };
 
             token.onCancellationRequested(() => {
                 (readable as any).destroy?.();
-                resolve();
+                resolveOnce();
             });
 
             readable.on('data', (chunk: Buffer) => {
-                buffer += chunk.toString('utf8');
-                const lines = buffer.split(/\r?\n/);
-                buffer = lines.pop() ?? '';
-
-                for (const line of lines) {
-                    const trimmed = line.trim();
-                    if (!trimmed || !trimmed.startsWith('data:')) {
-                        continue;
-                    }
-                    const payload = trimmed.slice(5).trim();
-                    if (payload === '[DONE]') {
-                        finalize();
-                        readable.removeAllListeners();
-                        return;
-                    }
-                    try {
-                        const json = JSON.parse(payload);
-                        if (json?.error) {
-                            const apiError = this.normalizeProviderApiError(json.error);
-                            this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, apiError, trace, `model=${model.id}`);
-                            reject(this.toProviderError(apiError, apiError));
-                            readable.removeAllListeners();
-                            return;
-                        }
-                        const choice = json.choices?.[0];
-                        if (!choice) {
-                            continue;
-                        }
-                        if (choice.error) {
-                            const apiError = this.normalizeProviderApiError(choice.error);
-                            this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, apiError, trace, `model=${model.id}`);
-                            reject(this.toProviderError(apiError, apiError));
-                            readable.removeAllListeners();
-                            return;
-                        }
-                        const delta = choice.delta ?? {};
-                        if (typeof delta.content === 'string' && delta.content) {
-                            progress.report(new vscode.LanguageModelTextPart(delta.content));
-                        }
-                        if (Array.isArray(delta.tool_calls)) {
-                            for (const tc of delta.tool_calls) {
-                                const idx: number = typeof tc.index === 'number' ? tc.index : 0;
-                                if (!toolCalls[idx]) {
-                                    toolCalls[idx] = { id: '', name: '', arguments: '' };
-                                }
-                                if (tc.id) {
-                                    toolCalls[idx].id = tc.id;
-                                }
-                                if (tc.function?.name) {
-                                    toolCalls[idx].name = tc.function.name;
-                                }
-                                if (tc.function?.arguments) {
-                                    toolCalls[idx].arguments += tc.function.arguments;
-                                }
-                            }
-                        }
-                    } catch {
-                        // Skip malformed SSE chunks
-                    }
+                processBufferedLines(chunk.toString('utf8'));
+                if (settled) {
+                    return;
                 }
             });
 
             readable.on('end', () => {
+                if (processBufferedLines('', true)) {
+                    return;
+                }
                 finalize();
             });
 
             readable.on('error', (err: Error) => {
-                this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, err, trace, `model=${model.id}`);
-                reject(this.toProviderError(this.extractProviderApiError(err), err));
+                rejectStreamError(this.extractProviderApiError(err), err);
             });
         });
     }

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -263,6 +263,8 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             let reportedResponsePart = false;
             let payloadCount = 0;
             let contentChunkCount = 0;
+            let reasoningChunkCount = 0;
+            let reasoningCharCount = 0;
             let toolCallDeltaCount = 0;
             let doneReceived = false;
             let lastFinishReason: string | undefined;
@@ -299,6 +301,22 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                 readable.removeAllListeners();
             };
 
+            const collectReasoningDelta = (delta: Record<string, unknown>) => {
+                const reasoningContent =
+                    typeof delta.reasoning_content === 'string'
+                        ? delta.reasoning_content
+                        : typeof delta.reasoningContent === 'string'
+                            ? delta.reasoningContent
+                            : undefined;
+
+                if (!reasoningContent) {
+                    return;
+                }
+
+                reasoningChunkCount += 1;
+                reasoningCharCount += reasoningContent.length;
+            };
+
             const processPayload = (payload: string): boolean => {
                 if (payload === '[DONE]') {
                     doneReceived = true;
@@ -329,7 +347,8 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         lastFinishReason = choice.finish_reason;
                     }
 
-                    const delta = choice.delta ?? {};
+                    const delta = (choice.delta ?? {}) as Record<string, unknown>;
+                    collectReasoningDelta(delta);
                     if (typeof delta.content === 'string') {
                         reportTextPart(delta.content);
                     }
@@ -410,6 +429,8 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                             `model=${model.id}`,
                             `payloads=${payloadCount}`,
                             `content_chunks=${contentChunkCount}`,
+                            `reasoning_chunks=${reasoningChunkCount}`,
+                            `reasoning_chars=${reasoningCharCount}`,
                             `tool_call_deltas=${toolCallDeltaCount}`,
                             `final_tool_calls=${toolCalls.filter(tc => tc.id && tc.name).length}`,
                             `done_received=${doneReceived}`,
@@ -417,7 +438,11 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         ].filter(Boolean).join(' | ')
                     );
 
-                    rejectOnce(this.createEmptyResponseError());
+                    rejectOnce(
+                        reasoningChunkCount > 0 && lastFinishReason === 'length'
+                            ? this.createReasoningOnlyEmptyResponseError()
+                            : this.createEmptyResponseError()
+                    );
                     return;
                 }
 
@@ -1001,6 +1026,15 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
     private createEmptyResponseError(): Error & { cause?: unknown } {
         const error = new Error(
             'The model returned an empty response. Try again, compact the conversation again, or start a new chat.'
+        ) as Error & { cause?: unknown };
+        error.name = 'LanguageModelProviderError';
+        error.stack = undefined;
+        return error;
+    }
+
+    private createReasoningOnlyEmptyResponseError(): Error & { cause?: unknown } {
+        const error = new Error(
+            'The model used the entire output budget on internal reasoning and returned no visible answer. Try again, compact the conversation again, start a new chat, or disable reasoning for this model.'
         ) as Error & { cause?: unknown };
         error.name = 'LanguageModelProviderError';
         error.stack = undefined;

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -274,6 +274,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             let toolCallDeltaCount = 0;
             let doneReceived = false;
             let lastFinishReason: string | undefined;
+            let responseUsage: Record<string, unknown> | undefined;
 
             const resolveOnce = () => {
                 if (settled) {
@@ -334,6 +335,9 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                 try {
                     payloadCount += 1;
                     const json = JSON.parse(payload);
+                    if (json?.usage && typeof json.usage === 'object') {
+                        responseUsage = json.usage as Record<string, unknown>;
+                    }
                     if (json?.error) {
                         rejectStreamError(this.normalizeProviderApiError(json.error), json.error);
                         return true;
@@ -422,6 +426,22 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         }
                     }
                 }
+
+                this.app.logger.addEventLog(
+                    'API',
+                    'CHAT_COMPLETIONS_POST_RESPONSE',
+                    [
+                        completionsUrl,
+                        `request_id=${trace.requestId}`,
+                        `caller=${trace.caller}`,
+                        trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
+                        typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
+                        `model=${model.id}`,
+                        `chosen_max_tokens=${chosenMaxTokens}`,
+                        lastFinishReason ? `finish_reason=${lastFinishReason}` : '',
+                        ...this.formatUsageLogFields(responseUsage),
+                    ].filter(Boolean).join(' | ')
+                );
 
                 if (!reportedResponsePart) {
                     this.app.logger.addEventLog(
@@ -906,6 +926,29 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
 
     private getPositiveTokenLimit(value: number, fallback: number): number {
         return Number.isFinite(value) && value > 0 ? value : fallback;
+    }
+
+    private formatUsageLogFields(usage: Record<string, unknown> | undefined): string[] {
+        const completionTokenDetails = this.getRecordField(usage, 'completion_tokens_details');
+        const promptTokenDetails = this.getRecordField(usage, 'prompt_tokens_details');
+
+        return [
+            `prompt_tokens=${this.getNumberField(usage, 'prompt_tokens') ?? 'unknown'}`,
+            `completion_tokens=${this.getNumberField(usage, 'completion_tokens') ?? 'unknown'}`,
+            `total_tokens=${this.getNumberField(usage, 'total_tokens') ?? 'unknown'}`,
+            `reasoning_tokens=${this.getNumberField(completionTokenDetails, 'reasoning_tokens') ?? 'unknown'}`,
+            `cached_prompt_tokens=${this.getNumberField(promptTokenDetails, 'cached_tokens') ?? 'unknown'}`,
+        ];
+    }
+
+    private getRecordField(record: Record<string, unknown> | undefined, field: string): Record<string, unknown> | undefined {
+        const value = record?.[field];
+        return value && typeof value === 'object' ? value as Record<string, unknown> : undefined;
+    }
+
+    private getNumberField(record: Record<string, unknown> | undefined, field: string): number | undefined {
+        const value = record?.[field];
+        return typeof value === 'number' ? value : undefined;
     }
 
     private async getExactPromptTokens(

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -261,6 +261,11 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             const toolCalls: { id: string; name: string; arguments: string }[] = [];
             let settled = false;
             let reportedResponsePart = false;
+            let payloadCount = 0;
+            let contentChunkCount = 0;
+            let toolCallDeltaCount = 0;
+            let doneReceived = false;
+            let lastFinishReason: string | undefined;
 
             const resolveOnce = () => {
                 if (settled) {
@@ -284,6 +289,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                 }
 
                 reportedResponsePart = true;
+                contentChunkCount += 1;
                 progress.report(new vscode.LanguageModelTextPart(content));
             };
 
@@ -295,12 +301,14 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
 
             const processPayload = (payload: string): boolean => {
                 if (payload === '[DONE]') {
+                    doneReceived = true;
                     finalize();
                     readable.removeAllListeners();
                     return true;
                 }
 
                 try {
+                    payloadCount += 1;
                     const json = JSON.parse(payload);
                     if (json?.error) {
                         rejectStreamError(this.normalizeProviderApiError(json.error), json.error);
@@ -317,12 +325,17 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         return true;
                     }
 
+                    if (typeof choice.finish_reason === 'string') {
+                        lastFinishReason = choice.finish_reason;
+                    }
+
                     const delta = choice.delta ?? {};
                     if (typeof delta.content === 'string') {
                         reportTextPart(delta.content);
                     }
 
                     if (Array.isArray(delta.tool_calls)) {
+                        toolCallDeltaCount += delta.tool_calls.length;
                         for (const tc of delta.tool_calls) {
                             const idx: number = typeof tc.index === 'number' ? tc.index : 0;
                             if (!toolCalls[idx]) {
@@ -395,12 +408,16 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                             trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
                             typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
                             `model=${model.id}`,
+                            `payloads=${payloadCount}`,
+                            `content_chunks=${contentChunkCount}`,
+                            `tool_call_deltas=${toolCallDeltaCount}`,
+                            `final_tool_calls=${toolCalls.filter(tc => tc.id && tc.name).length}`,
+                            `done_received=${doneReceived}`,
+                            lastFinishReason ? `finish_reason=${lastFinishReason}` : '',
                         ].filter(Boolean).join(' | ')
                     );
 
-                    const error = new Error('The model returned an empty response.') as Error & { cause?: unknown };
-                    error.name = 'LanguageModelProviderError';
-                    rejectOnce(error);
+                    rejectOnce(this.createEmptyResponseError());
                     return;
                 }
 
@@ -977,6 +994,15 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
         // VS Code's chat fetch path formats verbose errors as
         // `${error.message}: ${error.stack}`. For this user-correctable preflight
         // case, suppress the stack so the UI doesn't duplicate the message.
+        error.stack = undefined;
+        return error;
+    }
+
+    private createEmptyResponseError(): Error & { cause?: unknown } {
+        const error = new Error(
+            'The model returned an empty response. Try again, compact the conversation again, or start a new chat.'
+        ) as Error & { cause?: unknown };
+        error.name = 'LanguageModelProviderError';
         error.stack = undefined;
         return error;
     }

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -10,8 +10,9 @@ import {
     extractRuntimeContextSize,
     isLikelyLlamaCppProvider,
     OpenAICompatibleModel,
-    resolveRequestMaxOutputTokens,
     resolveModelTokenLimits,
+    resolveBoundedMaxOutputTokens,
+    resolveRequestMaxOutputTokens,
 } from './language-model-token-limits';
 import { Utils } from './utils';
 
@@ -197,9 +198,14 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             });
         }
         this.recordConversationBudget(trace, promptTokenEstimate, openaiMessages.length);
+        const boundedMaxOutputTokens = resolveBoundedMaxOutputTokens({
+            maxInputTokens: runtimeTokenLimits.maxInputTokens,
+            maxOutputTokens: this.getPositiveTokenLimit(runtimeTokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS),
+            defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        });
         const chosenMaxTokens = resolveRequestMaxOutputTokens({
             maxInputTokens: runtimeTokenLimits.maxInputTokens,
-            maxOutputTokens: Math.min(this.getPositiveTokenLimit(runtimeTokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS), DEFAULT_MAX_OUTPUT_TOKENS),
+            maxOutputTokens: boundedMaxOutputTokens,
             promptTokenEstimate,
             defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
             contextSafetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
@@ -210,7 +216,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             promptTokens: promptTokenEstimate,
             promptCountSource: exactPromptTokens === undefined ? 'fallback' : 'exact',
             maxInputTokens: runtimeTokenLimits.maxInputTokens,
-            maxOutputTokens: Math.min(this.getPositiveTokenLimit(runtimeTokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS), DEFAULT_MAX_OUTPUT_TOKENS),
+            maxOutputTokens: boundedMaxOutputTokens,
             chosenMaxTokens,
             safetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
         });

--- a/src/llama-chat-model-provider.ts
+++ b/src/llama-chat-model-provider.ts
@@ -1,21 +1,33 @@
 import * as vscode from 'vscode';
 import axios from 'axios';
 import { Application } from './application';
+import type { RequestTraceContext } from './llama-server';
+import {
+    buildRuntimePropsUrl,
+    DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    estimateTokenCount,
+    extractRuntimeContextSize,
+    isLikelyLlamaCppProvider,
+    OpenAICompatibleModel,
+    resolveRequestMaxOutputTokens,
+    resolveModelTokenLimits,
+} from './language-model-token-limits';
 import { Utils } from './utils';
 
 const VENDOR = 'llama-vscode';
 
-// Default token limits used when the server does not report them
-const DEFAULT_MAX_INPUT_TOKENS = 8192;
-const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
-
-interface OpenAIModel {
-    id: string;
-    object?: string;
+interface OpenAIModelsResponse {
+    data: OpenAICompatibleModel[];
 }
 
-interface OpenAIModelsResponse {
-    data: OpenAIModel[];
+interface ProviderApiError {
+    message: string;
+    type?: string;
+    status?: number;
+    n_prompt_tokens?: number;
+    n_ctx?: number;
+    [key: string]: unknown;
 }
 
 type OpenAIToolCall = {
@@ -39,10 +51,21 @@ type OpenAIChatMessage =
           tool_call_id: string;
       };
 
+type ConversationTraceState = {
+    conversationId: string;
+    anchorKey: string;
+    turn: number;
+    lastPromptTokens?: number;
+    lastMessageCount: number;
+    lastSeenAt: number;
+};
+
 export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider {
     private readonly _onDidChangeLanguageModelChatInformation = new vscode.EventEmitter<void>();
     readonly onDidChangeLanguageModelChatInformation: vscode.Event<void> =
         this._onDidChangeLanguageModelChatInformation.event;
+    private conversationCounter = 0;
+    private activeConversation: ConversationTraceState | undefined;
 
     constructor(private readonly app: Application) {}
 
@@ -55,13 +78,12 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
         _options: vscode.PrepareLanguageModelChatModelOptions,
         _token: vscode.CancellationToken
     ): Promise<vscode.LanguageModelChatInformation[]> {
-        const endpoint = this.getChatEndpoint();
+        const { endpoint, requestConfig } = this.getChatRequestDetails();
         if (!endpoint) {
             return [];
         }
 
         try {
-            const requestConfig = this.app.configuration.axiosRequestConfigChat;
             const response = await axios.get<OpenAIModelsResponse>(
                 `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/models`,
                 requestConfig
@@ -71,18 +93,28 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                 return [];
             }
 
-            return response.data.data.map((model) => ({
-                id: model.id,
-                name: model.id,
-                family: VENDOR,
-                version: '1',
-                maxInputTokens: DEFAULT_MAX_INPUT_TOKENS,
-                maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
-                capabilities: {
-                    toolCalling: true,
-                    imageInput: false,
-                },
-            }));
+            const runtimeContextSizes = await this.getRuntimeContextSizes(endpoint, response.data.data, requestConfig);
+
+            return response.data.data.map((model) => {
+                const tokenLimits = resolveModelTokenLimits(model, {
+                    configuredMaxInputTokens: this.app.configuration.lm_max_input_tokens,
+                    configuredMaxOutputTokens: this.app.configuration.lm_max_output_tokens,
+                    runtimeContextSize: runtimeContextSizes.get(model.id),
+                });
+
+                return {
+                    id: model.id,
+                    name: model.id,
+                    family: VENDOR,
+                    version: '1',
+                    maxInputTokens: tokenLimits.maxInputTokens,
+                    maxOutputTokens: tokenLimits.maxOutputTokens,
+                    capabilities: {
+                        toolCalling: true,
+                        imageInput: false,
+                    },
+                };
+            });
         } catch {
             return [];
         }
@@ -95,7 +127,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
         progress: vscode.Progress<vscode.LanguageModelResponsePart>,
         token: vscode.CancellationToken
     ): Promise<void> {
-        const endpoint = this.getChatEndpoint();
+        const { endpoint, requestConfig } = this.getChatRequestDetails();
         if (!endpoint) {
             throw new Error('No chat endpoint configured');
         }
@@ -110,6 +142,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                 parameters: t.inputSchema,
             },
         }));
+        const toolChoice = this.mapToolMode(options.toolMode, tools?.length ?? 0);
 
         if (tools?.length) {
             openaiMessages.unshift({
@@ -122,34 +155,112 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             model: model.id,
             messages: openaiMessages,
             stream: true,
-            max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
             ...(options.modelOptions?.temperature !== undefined && {
                 temperature: options.modelOptions.temperature,
             }),
             ...(tools?.length && { tools }),
-            ...(this.mapToolMode(options.toolMode, tools?.length ?? 0) && {
-                tool_choice: this.mapToolMode(options.toolMode, tools?.length ?? 0),
+            ...(toolChoice && {
+                tool_choice: toolChoice,
             }),
         };
 
         const abortController = new AbortController();
         token.onCancellationRequested(() => abortController.abort());
 
-        const requestConfig = this.app.configuration.axiosRequestConfigTools;
-        const streamResponse = await axios.post<NodeJS.ReadableStream>(
-            `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`,
-            requestBody,
-            { ...requestConfig, responseType: 'stream' as const, signal: abortController.signal }
+        const runtimeTokenLimits = await this.getRuntimeTokenLimitsForRequest(
+            endpoint,
+            model.id,
+            requestConfig,
+            model.maxInputTokens,
+            model.maxOutputTokens,
         );
+
+        const trace = this.getConversationTrace(openaiMessages);
+        this.logConversationTextSnapshot(messages, trace);
+        this.logConversationPartSnapshot(messages, trace);
+        const exactPromptTokens = await this.getExactPromptTokens(
+            openaiMessages,
+            endpoint,
+            model.id,
+            requestConfig,
+            trace,
+            tools,
+            toolChoice
+        );
+        const promptTokenEstimate = exactPromptTokens ?? this.estimatePromptTokens(openaiMessages);
+        if (exactPromptTokens === undefined) {
+            this.app.llamaServer.logBudgetFallback(trace, {
+                endpoint,
+                model: model.id,
+                fallbackPromptTokens: promptTokenEstimate,
+                fallbackReason: 'exact_count_unavailable',
+            });
+        }
+        this.recordConversationBudget(trace, promptTokenEstimate, openaiMessages.length);
+        const chosenMaxTokens = resolveRequestMaxOutputTokens({
+            maxInputTokens: runtimeTokenLimits.maxInputTokens,
+            maxOutputTokens: Math.min(this.getPositiveTokenLimit(runtimeTokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS), DEFAULT_MAX_OUTPUT_TOKENS),
+            promptTokenEstimate,
+            defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+            contextSafetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+        });
+        this.app.llamaServer.logBudgetDecision(trace, {
+            endpoint,
+            model: model.id,
+            promptTokens: promptTokenEstimate,
+            promptCountSource: exactPromptTokens === undefined ? 'fallback' : 'exact',
+            maxInputTokens: runtimeTokenLimits.maxInputTokens,
+            maxOutputTokens: Math.min(this.getPositiveTokenLimit(runtimeTokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS), DEFAULT_MAX_OUTPUT_TOKENS),
+            chosenMaxTokens,
+            safetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+        });
+
+        if (exactPromptTokens !== undefined && promptTokenEstimate >= runtimeTokenLimits.maxInputTokens) {
+            this.app.logger.addEventLog(
+                'BUDGET',
+                'REQUEST_REJECTED',
+                [
+                    `request_id=${trace.requestId}`,
+                    `caller=${trace.caller}`,
+                    trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
+                    typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
+                    `endpoint=${endpoint}`,
+                    `model=${model.id}`,
+                    `prompt_tokens=${promptTokenEstimate}`,
+                    `max_input_tokens=${runtimeTokenLimits.maxInputTokens}`,
+                    'reason=prompt_exceeds_context_window',
+                ].filter(Boolean).join(' | ')
+            );
+
+            throw this.createContextWindowExceededError(
+                promptTokenEstimate,
+                runtimeTokenLimits.maxInputTokens,
+                `Prompt token count was measured exactly before sending.`
+            );
+        }
+
+        const completionsUrl = `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`;
+        let streamResponse: { data: NodeJS.ReadableStream };
+        try {
+            streamResponse = await axios.post<NodeJS.ReadableStream>(
+                completionsUrl,
+                {
+                    ...requestBody,
+                    max_tokens: chosenMaxTokens,
+                },
+                { ...requestConfig, responseType: 'stream' as const, signal: abortController.signal }
+            );
+        } catch (error) {
+            this.logProviderApiError('CHAT_COMPLETIONS_POST_ERROR', completionsUrl, error, trace, `model=${model.id}`);
+            throw this.toProviderError(this.extractProviderApiError(error), error);
+        }
 
         await new Promise<void>((resolve, reject) => {
             const readable = streamResponse.data;
             let buffer = '';
-            // Accumulated tool call data indexed by call index
             const toolCalls: { id: string; name: string; arguments: string }[] = [];
 
             const finalize = () => {
-                // Emit any completed tool calls that weren't emitted yet
                 for (const tc of toolCalls) {
                     if (tc.id && tc.name) {
                         try {
@@ -187,9 +298,23 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                     }
                     try {
                         const json = JSON.parse(payload);
+                        if (json?.error) {
+                            const apiError = this.normalizeProviderApiError(json.error);
+                            this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, apiError, trace, `model=${model.id}`);
+                            reject(this.toProviderError(apiError, apiError));
+                            readable.removeAllListeners();
+                            return;
+                        }
                         const choice = json.choices?.[0];
                         if (!choice) {
                             continue;
+                        }
+                        if (choice.error) {
+                            const apiError = this.normalizeProviderApiError(choice.error);
+                            this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, apiError, trace, `model=${model.id}`);
+                            reject(this.toProviderError(apiError, apiError));
+                            readable.removeAllListeners();
+                            return;
                         }
                         const delta = choice.delta ?? {};
                         if (typeof delta.content === 'string' && delta.content) {
@@ -223,40 +348,247 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             });
 
             readable.on('error', (err: Error) => {
-                reject(err);
+                this.logProviderApiError('CHAT_COMPLETIONS_STREAM_ERROR', completionsUrl, err, trace, `model=${model.id}`);
+                reject(this.toProviderError(this.extractProviderApiError(err), err));
             });
         });
     }
 
     provideTokenCount(
-        _model: vscode.LanguageModelChatInformation,
+        model: vscode.LanguageModelChatInformation,
         text: string | vscode.LanguageModelChatRequestMessage,
         _token: vscode.CancellationToken
     ): Thenable<number> {
-        const content =
-            typeof text === 'string'
-                ? text
-                : text.content
-                      .map((p: unknown) => (p instanceof vscode.LanguageModelTextPart ? p.value : ''))
-                      .join('');
-        // Rough approximation: 1 token ≈ 4 characters. The llama.cpp server does not expose a
-        // tokenization endpoint via the standard OpenAI API, so we use this heuristic.
-        // Actual token counts may differ depending on the model's tokenizer.
-        return Promise.resolve(Math.ceil(content.length / 4));
+        // VS Code can call provideTokenCount very frequently while preparing and
+        // updating chat UI state. Do not make network round-trips here.
+        //
+        // Exact server-side counting is still used on the actual send path when
+        // we clamp request max_tokens. This callback should stay cheap and local.
+        if (typeof text === 'string') {
+            const tokenCount = estimateTokenCount(text);
+            return Promise.resolve(tokenCount);
+        }
+
+        const openaiMessages = [this.toOpenAIMessage(text)];
+        const tokenCount = this.estimatePromptTokens(openaiMessages);
+        return Promise.resolve(tokenCount);
     }
 
-    private getChatEndpoint(): string {
+    private getChatRequestDetails(): { endpoint: string; requestConfig: object } {
         const selectedModel = this.app.getToolsModel();
         if (selectedModel?.endpoint) {
-            return selectedModel.endpoint;
+            if (selectedModel.isKeyRequired) {
+                const apiKey = this.app.persistence.getApiKey(selectedModel.endpoint);
+                if (apiKey) {
+                    return {
+                        endpoint: selectedModel.endpoint,
+                        requestConfig: {
+                            headers: {
+                                Authorization: `Bearer ${apiKey}`,
+                                'Content-Type': 'application/json',
+                            },
+                        },
+                    };
+                }
+            }
+
+            return {
+                endpoint: selectedModel.endpoint,
+                requestConfig: this.app.configuration.axiosRequestConfigTools,
+            };
         }
         if (this.app.configuration.endpoint_chat) {
-            return this.app.configuration.endpoint_chat;
+            return {
+                endpoint: this.app.configuration.endpoint_chat,
+                requestConfig: this.app.configuration.axiosRequestConfigChat,
+            };
         }
         if (this.app.configuration.endpoint_tools) {
-            return this.app.configuration.endpoint_tools;
+            return {
+                endpoint: this.app.configuration.endpoint_tools,
+                requestConfig: this.app.configuration.axiosRequestConfigTools,
+            };
         }
-        return '';
+
+        return {
+            endpoint: '',
+            requestConfig: this.app.configuration.axiosRequestConfigTools,
+        };
+    }
+
+    private logProviderApiError(
+        event: string,
+        url: string,
+        error: unknown,
+        trace: RequestTraceContext,
+        details = ''
+    ): void {
+        const apiError = this.extractProviderApiError(error);
+        this.app.logger.addEventLog(
+            'API',
+            event,
+            [
+                url,
+                `request_id=${trace.requestId}`,
+                `caller=${trace.caller}`,
+                trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
+                typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
+                details,
+                `error=${apiError.message.replace(/\r?\n/g, ' ')}`,
+                apiError.status ? `status=${apiError.status}` : '',
+                apiError.type ? `type=${apiError.type}` : '',
+                typeof apiError.n_prompt_tokens === 'number' ? `n_prompt_tokens=${apiError.n_prompt_tokens}` : '',
+                typeof apiError.n_ctx === 'number' ? `n_ctx=${apiError.n_ctx}` : '',
+            ].filter(Boolean).join(' | ')
+        );
+    }
+
+    private getConversationTrace(messages: OpenAIChatMessage[]): RequestTraceContext {
+        const anchorKey = this.getConversationAnchorKey(messages);
+        const shouldStartNewConversation = !this.activeConversation
+            || (
+                messages.length <= 3
+                && anchorKey !== ''
+                && anchorKey !== this.activeConversation.anchorKey
+            );
+
+        if (shouldStartNewConversation) {
+            this.conversationCounter += 1;
+            this.activeConversation = {
+                conversationId: `conv-${Date.now().toString(36)}-${this.conversationCounter.toString(36)}`,
+                anchorKey,
+                turn: 0,
+                lastMessageCount: messages.length,
+                lastSeenAt: Date.now(),
+            };
+        }
+
+        const conversation = this.activeConversation;
+        if (!conversation) {
+            return this.app.llamaServer.createRequestTrace('lm-provider');
+        }
+
+        conversation.turn += 1;
+        conversation.lastSeenAt = Date.now();
+        conversation.lastMessageCount = messages.length;
+        if (!conversation.anchorKey && anchorKey) {
+            conversation.anchorKey = anchorKey;
+        }
+
+        const trace = this.app.llamaServer.createRequestTrace('lm-provider');
+        trace.conversationId = conversation.conversationId;
+        trace.conversationTurn = conversation.turn;
+        return trace;
+    }
+
+    private recordConversationBudget(
+        trace: RequestTraceContext,
+        promptTokens: number,
+        messageCount: number,
+    ): void {
+        if (!this.activeConversation || this.activeConversation.conversationId !== trace.conversationId) {
+            return;
+        }
+
+        const previousPromptTokens = this.activeConversation.lastPromptTokens;
+        const previousMessageCount = this.activeConversation.lastMessageCount;
+        if (
+            typeof previousPromptTokens === 'number'
+            && promptTokens + 2048 < previousPromptTokens
+            && messageCount <= previousMessageCount + 2
+        ) {
+            this.app.logger.addEventLog(
+                'CONVERSATION',
+                'COMPACTED',
+                [
+                    `conversation_id=${trace.conversationId}`,
+                    `conversation_turn=${trace.conversationTurn ?? 'unknown'}`,
+                    `prompt_tokens_before=${previousPromptTokens}`,
+                    `prompt_tokens_after=${promptTokens}`,
+                    `messages_before=${previousMessageCount}`,
+                    `messages_after=${messageCount}`,
+                ].join(' | ')
+            );
+        }
+
+        this.activeConversation.lastPromptTokens = promptTokens;
+        this.activeConversation.lastMessageCount = messageCount;
+        this.activeConversation.lastSeenAt = Date.now();
+    }
+
+    private logConversationTextSnapshot(
+        messages: readonly vscode.LanguageModelChatRequestMessage[],
+        trace: RequestTraceContext,
+    ): void {
+        const textMessages = messages
+            .map((message) => {
+                const text = this.extractTextFromParts(message.content)
+                    .replace(/\s+/g, ' ')
+                    .trim();
+
+                if (!text) {
+                    return undefined;
+                }
+
+                return {
+                    role: message.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant',
+                    text,
+                };
+            })
+            .filter((message): message is { role: 'user' | 'assistant'; text: string } => message !== undefined)
+            .slice(-5);
+
+        this.app.logger.addEventLog(
+            'CONVERSATION',
+            'TEXT_SNAPSHOT',
+            [
+                `conversation_id=${trace.conversationId ?? 'unknown'}`,
+                `conversation_turn=${trace.conversationTurn ?? 'unknown'}`,
+                `messages=${textMessages.length}`,
+                ...textMessages.map((message, index) => `${index + 1}:${message.role}:${this.toLogSnippet(message.text)}`),
+            ].join('\n')
+        );
+    }
+
+    private logConversationPartSnapshot(
+        messages: readonly vscode.LanguageModelChatRequestMessage[],
+        trace: RequestTraceContext,
+    ): void {
+        const snapshotLines = messages
+            .slice(-5)
+            .map((message, messageIndex) => {
+                const role = message.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant';
+                const parts = message.content
+                    .map((part, partIndex) => `${partIndex + 1}:${this.describePart(part)}`)
+                    .join(' || ');
+                return `${messageIndex + 1}:${role}:${parts || 'no-parts'}`;
+            });
+
+        this.app.logger.addEventLog(
+            'CONVERSATION',
+            'PART_SNAPSHOT',
+            [
+                `conversation_id=${trace.conversationId ?? 'unknown'}`,
+                `conversation_turn=${trace.conversationTurn ?? 'unknown'}`,
+                `messages=${Math.min(messages.length, 5)}`,
+                ...snapshotLines,
+            ].join('\n')
+        );
+    }
+
+    private getConversationAnchorKey(messages: OpenAIChatMessage[]): string {
+        const firstUserMessage = messages.find(
+            (message) => message.role === 'user' && typeof message.content === 'string' && message.content.trim() !== ''
+        );
+        if (!firstUserMessage || typeof firstUserMessage.content !== 'string') {
+            return '';
+        }
+
+        return firstUserMessage.content
+            .replace(/\s+/g, ' ')
+            .trim()
+            .slice(0, 120)
+            .toLowerCase();
     }
 
     private toOpenAIMessages(
@@ -270,11 +602,6 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
             const toolResults: Array<{ callId: string; content: string }> = [];
 
             for (const part of msg.content) {
-                if (part instanceof vscode.LanguageModelTextPart) {
-                    textParts.push(part.value);
-                    continue;
-                }
-
                 if (part instanceof vscode.LanguageModelToolCallPart) {
                     toolCalls.push({
                         id: part.callId,
@@ -292,6 +619,12 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
                         callId: part.callId,
                         content: this.stringifyToolResult(part.content),
                     });
+                    continue;
+                }
+
+                const extractedText = this.extractTextFromPart(part);
+                if (extractedText) {
+                    textParts.push(extractedText);
                 }
             }
 
@@ -331,22 +664,7 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
 
     private stringifyToolResult(content: readonly unknown[]): string {
         return content
-            .map((item) => {
-                if (typeof item === 'string') {
-                    return item;
-                }
-
-                if (item instanceof vscode.LanguageModelTextPart) {
-                    return item.value;
-                }
-
-                if (item && typeof item === 'object' && 'value' in item) {
-                    const value = (item as { value: unknown }).value;
-                    return typeof value === 'string' ? value : JSON.stringify(value);
-                }
-
-                return JSON.stringify(item);
-            })
+            .map((item) => this.extractTextFromPart(item) || JSON.stringify(item))
             .filter((item) => item && item !== 'null' && item !== 'undefined')
             .join('\n');
     }
@@ -364,5 +682,340 @@ export class LlamaChatModelProvider implements vscode.LanguageModelChatProvider 
         }
 
         return 'auto';
+    }
+
+    private async getRuntimeContextSizes(
+        endpoint: string,
+        models: OpenAICompatibleModel[],
+        requestConfig: object
+    ): Promise<Map<string, number>> {
+        if (this.app.configuration.lm_max_input_tokens > 0 || !isLikelyLlamaCppProvider(models)) {
+            return new Map();
+        }
+
+        if (models.length === 1) {
+            const runtimeContextSize = await this.fetchRuntimeContextSize(
+                buildRuntimePropsUrl(endpoint),
+                requestConfig
+            );
+            return runtimeContextSize === undefined ? new Map() : new Map([[models[0].id, runtimeContextSize]]);
+        }
+
+        const runtimeContexts = await Promise.all(
+            models.map(async (model) => {
+                const runtimeContextSize = await this.fetchRuntimeContextSize(
+                    buildRuntimePropsUrl(endpoint, model.id),
+                    requestConfig
+                );
+                return [model.id, runtimeContextSize] as const;
+            })
+        );
+
+        return new Map(
+            runtimeContexts.filter(
+                (entry): entry is readonly [string, number] => entry[1] !== undefined
+            )
+        );
+    }
+
+    private async fetchRuntimeContextSize(
+        propsUrl: string,
+        requestConfig: object
+    ): Promise<number | undefined> {
+        try {
+            const propsResponse = await axios.get(propsUrl, requestConfig);
+            return extractRuntimeContextSize(propsResponse.data);
+        } catch {
+            return undefined;
+        }
+    }
+
+    private async getRuntimeTokenLimitsForRequest(
+        endpoint: string,
+        modelId: string,
+        requestConfig: object,
+        fallbackMaxInputTokens: number,
+        fallbackMaxOutputTokens: number,
+    ): Promise<{ maxInputTokens: number; maxOutputTokens: number }> {
+        try {
+            const response = await axios.get<OpenAIModelsResponse>(
+                `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/models`,
+                requestConfig
+            );
+
+            const models = response.data?.data ?? [];
+            const matchedModel =
+                models.find((candidate) => candidate.id === modelId)
+                ?? (models.length === 1 ? models[0] : undefined);
+
+            if (!matchedModel) {
+                return {
+                    maxInputTokens: fallbackMaxInputTokens,
+                    maxOutputTokens: fallbackMaxOutputTokens,
+                };
+            }
+
+            let runtimeContextSize: number | undefined;
+            if (this.app.configuration.lm_max_input_tokens <= 0 && isLikelyLlamaCppProvider([matchedModel])) {
+                const propsUrl = models.length === 1
+                    ? buildRuntimePropsUrl(endpoint)
+                    : buildRuntimePropsUrl(endpoint, matchedModel.id);
+                runtimeContextSize = await this.fetchRuntimeContextSize(propsUrl, requestConfig);
+            }
+
+            return resolveModelTokenLimits(matchedModel, {
+                configuredMaxInputTokens: this.app.configuration.lm_max_input_tokens,
+                configuredMaxOutputTokens: this.app.configuration.lm_max_output_tokens,
+                runtimeContextSize,
+                defaultMaxInputTokens: fallbackMaxInputTokens,
+                defaultMaxOutputTokens: fallbackMaxOutputTokens,
+            });
+        } catch {
+            return {
+                maxInputTokens: fallbackMaxInputTokens,
+                maxOutputTokens: fallbackMaxOutputTokens,
+            };
+        }
+    }
+
+    private getPositiveTokenLimit(value: number, fallback: number): number {
+        return Number.isFinite(value) && value > 0 ? value : fallback;
+    }
+
+    private async getExactPromptTokens(
+        messages: OpenAIChatMessage[],
+        endpoint: string,
+        modelId: string,
+        requestConfig: object,
+        trace: RequestTraceContext,
+        tools?: unknown[],
+        toolChoice?: 'auto' | 'required'
+    ): Promise<number | undefined> {
+        return this.app.llamaServer.countToolsPromptTokens(messages as any, '', {
+            endpoint,
+            model: modelId,
+            requestConfig,
+            trace,
+            tools,
+            toolChoice,
+        });
+    }
+
+    private estimatePromptTokens(messages: readonly OpenAIChatMessage[]): number {
+        // Fallback only: prefer server-side apply-template + tokenize whenever available.
+        return estimateTokenCount(messages);
+    }
+
+    private extractTextFromParts(parts: readonly unknown[]): string {
+        return parts
+            .map((part) => this.extractTextFromPart(part))
+            .filter((value): value is string => Boolean(value))
+            .join('');
+    }
+
+    private extractProviderApiError(error: unknown): ProviderApiError {
+        if (axios.isAxiosError(error)) {
+            const responseData = error.response?.data as { error?: ProviderApiError } | ProviderApiError | undefined;
+            if (responseData && typeof responseData === 'object' && 'error' in responseData && responseData.error) {
+                return this.normalizeProviderApiError(responseData.error);
+            }
+
+            if (responseData && typeof responseData === 'object' && 'message' in responseData) {
+                return this.normalizeProviderApiError(responseData);
+            }
+
+            return this.normalizeProviderApiError({
+                message: error.message,
+                ...(typeof error.response?.status === 'number' && { status: error.response.status }),
+            });
+        }
+
+        if (error instanceof Error) {
+            return { message: error.message };
+        }
+
+        return this.normalizeProviderApiError(error);
+    }
+
+    private normalizeProviderApiError(error: unknown): ProviderApiError {
+        if (error && typeof error === 'object') {
+            const record = error as Record<string, unknown>;
+            return {
+                message: typeof record.message === 'string' ? record.message : JSON.stringify(error),
+                ...(typeof record.type === 'string' && { type: record.type }),
+                ...(typeof record.status === 'number' && { status: record.status }),
+                ...(typeof record.n_prompt_tokens === 'number' && { n_prompt_tokens: record.n_prompt_tokens }),
+                ...(typeof record.n_ctx === 'number' && { n_ctx: record.n_ctx }),
+            };
+        }
+
+        if (typeof error === 'string') {
+            return { message: error };
+        }
+
+        return { message: String(error) };
+    }
+
+    private toProviderError(apiError: ProviderApiError, rawError: unknown): Error {
+        if (apiError.status === 401 || apiError.status === 403) {
+            return vscode.LanguageModelError.NoPermissions(apiError.message);
+        }
+
+        if (apiError.status === 404) {
+            return vscode.LanguageModelError.NotFound(apiError.message);
+        }
+
+        if (apiError.status === 429) {
+            return vscode.LanguageModelError.Blocked(apiError.message);
+        }
+
+        if (this.isContextWindowExceededError(apiError)) {
+            const error = this.createContextWindowExceededError(apiError.n_prompt_tokens, apiError.n_ctx);
+            error.cause = rawError;
+            return error;
+        }
+
+        const error = new Error(apiError.message) as Error & { cause?: unknown };
+        error.cause = rawError;
+        error.name = 'LanguageModelProviderError';
+        return error;
+    }
+
+    private isContextWindowExceededError(apiError: ProviderApiError): boolean {
+        return /context_length_exceeded|exceeds the available context size|exceeds the context size/i.test(apiError.message);
+    }
+
+    private createContextWindowExceededError(
+        promptTokens: number | undefined,
+        maxInputTokens: number | undefined,
+        details?: string,
+    ): Error & { cause?: unknown } {
+        const promptTokenText = typeof promptTokens === 'number' ? promptTokens.toString() : 'unknown';
+        const maxInputTokenText = typeof maxInputTokens === 'number' ? maxInputTokens.toString() : 'unknown';
+        const error = new Error(
+            `This chat request exceeds the model context window (${promptTokenText} prompt tokens for a ${maxInputTokenText}-token limit). Start a new chat, compact the conversation again, or reduce the included context.${details ? ` ${details}` : ''}`
+        ) as Error & { cause?: unknown };
+        error.name = 'LanguageModelProviderError';
+        // VS Code's chat fetch path formats verbose errors as
+        // `${error.message}: ${error.stack}`. For this user-correctable preflight
+        // case, suppress the stack so the UI doesn't duplicate the message.
+        error.stack = undefined;
+        return error;
+    }
+
+    private extractTextFromPart(part: unknown, depth = 0): string {
+        if (depth > 4 || part === undefined || part === null) {
+            return '';
+        }
+
+        if (typeof part === 'string') {
+            return part;
+        }
+
+        if (part instanceof vscode.LanguageModelTextPart) {
+            return part.value;
+        }
+
+        if (part instanceof vscode.LanguageModelDataPart) {
+            const mimeType = part.mimeType.toLowerCase();
+            if (mimeType.startsWith('text/') || mimeType === 'application/json') {
+                return Buffer.from(part.data).toString('utf8');
+            }
+            return '';
+        }
+
+        if (part instanceof vscode.LanguageModelPromptTsxPart) {
+            return this.extractTextFromPart(part.value, depth + 1);
+        }
+
+        if (Array.isArray(part)) {
+            return part.map((item) => this.extractTextFromPart(item, depth + 1)).join('');
+        }
+
+        if (typeof part === 'object') {
+            const record = part as Record<string, unknown>;
+            const candidateKeys = ['text', 'value', 'content', 'children', 'prompt', 'message'];
+            return candidateKeys
+                .filter((key) => key in record)
+                .map((key) => this.extractTextFromPart(record[key], depth + 1))
+                .join('');
+        }
+
+        return '';
+    }
+
+    private describePart(part: unknown): string {
+        if (part instanceof vscode.LanguageModelTextPart) {
+            return `Text(${this.toLogSnippet(part.value)})`;
+        }
+
+        if (part instanceof vscode.LanguageModelToolCallPart) {
+            return `ToolCall(${part.name})`;
+        }
+
+        if (part instanceof vscode.LanguageModelToolResultPart) {
+            return `ToolResult(${part.callId}, parts=${part.content.length})`;
+        }
+
+        if (part instanceof vscode.LanguageModelPromptTsxPart) {
+            return `PromptTsx(${this.toLogSnippet(this.previewUnknown(part.value))})`;
+        }
+
+        if (part instanceof vscode.LanguageModelDataPart) {
+            const preview = part.mimeType.startsWith('text/') || part.mimeType === 'application/json'
+                ? this.toLogSnippet(Buffer.from(part.data).toString('utf8'))
+                : `bytes=${part.data.byteLength}`;
+            return `Data(${part.mimeType}, ${preview})`;
+        }
+
+        if (typeof part === 'string') {
+            return `String(${this.toLogSnippet(part)})`;
+        }
+
+        return `${this.getPartKind(part)}(${this.toLogSnippet(this.previewUnknown(part))})`;
+    }
+
+    private getPartKind(part: unknown): string {
+        if (part === null) {
+            return 'Null';
+        }
+
+        if (part === undefined) {
+            return 'Undefined';
+        }
+
+        if (typeof part !== 'object') {
+            return typeof part;
+        }
+
+        const constructorName = (part as { constructor?: { name?: string } }).constructor?.name;
+        return constructorName || 'Object';
+    }
+
+    private previewUnknown(part: unknown): string {
+        try {
+            if (typeof part === 'string') {
+                return part;
+            }
+
+            return JSON.stringify(part);
+        } catch {
+            return String(part);
+        }
+    }
+
+    private toLogSnippet(text: string): string {
+        if (text.length <= 60) {
+            return text;
+        }
+
+        return `${text.slice(0, 60)}...`;
+    }
+
+    private toOpenAIMessage(msg: vscode.LanguageModelChatRequestMessage): OpenAIChatMessage {
+        return {
+            role: msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant',
+            content: this.extractTextFromParts(msg.content),
+        };
     }
 }

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -8,14 +8,45 @@ import * as util from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ModelType, SUPPORTED_IMG_FILE_EXTS } from "./constants";
+import {
+    buildRuntimePropsUrl,
+    DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    estimateTokenCount,
+    extractRuntimeContextSize,
+    isLikelyLlamaCppProvider,
+    OpenAICompatibleModel,
+    resolveModelTokenLimits,
+    resolveRequestMaxOutputTokens,
+    ResolvedModelTokenLimits,
+} from './language-model-token-limits';
 
 const STATUS_OK = 200;
 
 export interface LlamaToolsResponse {
     choices: [{
-        message:{content?: string, tool_calls?:[{id:string, function: {name:string, arguments: string}}]},
+        message:{content?: string | null, tool_calls?:[{id:string, function: {name:string, arguments: string}}]},
         finish_reason?: string,
+        error?: LlamaApiError,
     }];
+    error?: LlamaApiError;
+    truncated?: boolean;
+    tokens_cached?: number;
+    timings?: LlamaResponse['timings'];
+    generation_settings?: LlamaResponse['generation_settings'];
+    usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
+    };
+}
+
+interface LlamaApiError {
+    message: string;
+    type?: string;
+    n_prompt_tokens?: number;
+    n_ctx?: number;
+    [key: string]: unknown;
 }
 
 export interface LlamaEmbeddingsResponse {
@@ -34,6 +65,44 @@ export interface LlamaEmbeddingsResponse {
     ]
 }
 
+interface ApplyTemplateResponse {
+    prompt: string;
+}
+
+interface TokenizeResponse {
+    tokens: unknown[];
+}
+
+interface OpenAIModelsResponse {
+    data: OpenAICompatibleModel[];
+}
+
+interface RequestDetailsOverride {
+    endpoint: string;
+    model?: string;
+    requestConfig?: AxiosRequestConfig;
+    trace?: RequestTraceContext;
+    tools?: unknown[];
+    toolChoice?: unknown;
+}
+
+interface ResolvedRequestDetails {
+    endpoint: string;
+    model: string;
+    requestConfig: AxiosRequestConfig;
+    selectedModel: LlmModel;
+    trace?: RequestTraceContext;
+    tools?: unknown[];
+    toolChoice?: unknown;
+}
+
+export interface RequestTraceContext {
+    requestId: string;
+    caller: string;
+    conversationId?: string;
+    conversationTurn?: number;
+}
+
 export class LlamaServer {
     private app: Application
     private vsCodeFimTerminal: Terminal | undefined;
@@ -43,6 +112,10 @@ export class LlamaServer {
     private vsCodeCommandTerminal: Terminal | undefined;
     private vsCodeToolsTerminal: Terminal | undefined;
     private aiModel = "";
+    private requestTraceCounter = 0;
+    private toolsTokenLimitsCache:
+        | { key: string; expiresAt: number; limits: ResolvedModelTokenLimits }
+        | undefined;
     private readonly defaultRequestParams = {
         top_k: 40,
         top_p: 0.99,
@@ -237,15 +310,74 @@ export class LlamaServer {
           };
     }
 
-    private createToolsRequestPayload(messages: ChatMessage[], model: string, stream = false, imagePath: string = "") {
-        this.app.tools.addSelectedTools();
-        let filteredMsgs = this.filterThoughtFromMsgs(messages)
+    private getToolsRequestDetails(): ResolvedRequestDetails {
+        const selectedModel: LlmModel = this.app.getToolsModel();
+        let model = this.app.configuration.ai_model;
+        if (selectedModel?.aiModel) {
+            model = selectedModel.aiModel;
+        }
 
-        // Add image with base64 encoding
+        let endpoint = this.app.configuration.endpoint_tools;
+        if (selectedModel?.endpoint) {
+            endpoint = selectedModel.endpoint;
+        }
+
+        let requestConfig = this.app.configuration.axiosRequestConfigTools;
+        if (selectedModel?.isKeyRequired) {
+            const apiKey = this.app.persistence.getApiKey(selectedModel.endpoint ?? "");
+            if (apiKey) {
+                requestConfig = {
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                };
+            }
+        }
+
+        return {
+            endpoint,
+            model,
+            requestConfig,
+            selectedModel,
+        };
+    }
+
+    createRequestTrace(caller: string): RequestTraceContext {
+        this.requestTraceCounter += 1;
+        return {
+            requestId: `${caller}-${Date.now().toString(36)}-${this.requestTraceCounter.toString(36)}`,
+            caller,
+        };
+    }
+
+    private resolveRequestDetails(override?: RequestDetailsOverride): ResolvedRequestDetails {
+        const details = this.getToolsRequestDetails();
+        if (!override) {
+            return {
+                ...details,
+                trace: undefined,
+            };
+        }
+
+        return {
+            ...details,
+            endpoint: override.endpoint,
+            model: override.model ?? details.model,
+            requestConfig: override.requestConfig ?? details.requestConfig,
+            trace: override.trace,
+            tools: override.tools,
+            toolChoice: override.toolChoice,
+        };
+    }
+
+    private buildToolsMessages(messages: ChatMessage[], imagePath = "") {
+        let filteredMsgs = this.filterThoughtFromMsgs(messages);
+
         if (imagePath && fs.existsSync(imagePath)) {
 
-            var imgType = ""
-            for (var suffix in SUPPORTED_IMG_FILE_EXTS){
+            let imgType = "";
+            for (const suffix in SUPPORTED_IMG_FILE_EXTS){
                 if (imagePath.endsWith(suffix)) {
                     imgType = SUPPORTED_IMG_FILE_EXTS[suffix];
                     break;
@@ -269,10 +401,17 @@ export class LlamaServer {
                         }
                     ]
                 };
-                filteredMsgs = (filteredMsgs as any[])
+                filteredMsgs = filteredMsgs as any[];
                 filteredMsgs.push(imageMessage);
             }
         }
+
+        return filteredMsgs;
+    }
+
+    private createToolsRequestPayload(messages: ChatMessage[], model: string, stream = false, imagePath: string = "") {
+        this.app.tools.addSelectedTools();
+        const filteredMsgs = this.buildToolsMessages(messages, imagePath);
 
             return {
             "messages": filteredMsgs,
@@ -283,6 +422,309 @@ export class LlamaServer {
             "tools": [...this.app.tools.getTools(),  ...this.app.tools.vscodeTools],
             "tool_choice": "auto"
         };
+    }
+
+    private summarizeTemplateMessages(messages: unknown[]): string {
+        const roles = messages.map((message, index) => {
+            if (!message || typeof message !== 'object') {
+                return `${index}:invalid`;
+            }
+
+            const role = (message as { role?: unknown }).role;
+            return `${index}:${typeof role === 'string' ? role : 'missing-role'}`;
+        });
+
+        return `count=${messages.length}; roles=[${roles.join(', ')}]`;
+    }
+
+    private formatTraceDetails(trace?: RequestTraceContext): string {
+        if (!trace) {
+            return '';
+        }
+
+        return [
+            `request_id=${trace.requestId}`,
+            `caller=${trace.caller}`,
+            trace.conversationId ? `conversation_id=${trace.conversationId}` : '',
+            typeof trace.conversationTurn === 'number' ? `conversation_turn=${trace.conversationTurn}` : '',
+        ].filter(Boolean).join(' | ');
+    }
+
+    private logApiRequest(label: string, method: string, url: string, details = "", trace?: RequestTraceContext) {
+        this.app.logger.addEventLog('API', `${label}_${method}_REQUEST`, [url, this.formatTraceDetails(trace), details].filter(Boolean).join(' | '));
+    }
+
+    private logApiResponse(label: string, method: string, url: string, details = "", trace?: RequestTraceContext) {
+        this.app.logger.addEventLog('API', `${label}_${method}_RESPONSE`, [url, this.formatTraceDetails(trace), details].filter(Boolean).join(' | '));
+    }
+
+    private logApiError(label: string, method: string, url: string, error: unknown, details = "", trace?: RequestTraceContext) {
+        const apiError = this.extractApiError(error);
+        this.app.logger.addEventLog(
+            'API',
+            `${label}_${method}_ERROR`,
+            [url, this.formatTraceDetails(trace), details, `error=${apiError.message.replace(/\r?\n/g, ' ')}`].filter(Boolean).join(' | ')
+        );
+    }
+
+    logBudgetDecision(
+        trace: RequestTraceContext,
+        details: {
+            endpoint: string;
+            model: string;
+            promptTokens?: number;
+            promptCountSource: 'exact' | 'fallback';
+            maxInputTokens: number;
+            maxOutputTokens: number;
+            chosenMaxTokens: number;
+            safetyMarginTokens: number;
+        }
+    ) {
+        this.app.logger.addEventLog(
+            'BUDGET',
+            'REQUEST_DECISION',
+            [
+                this.formatTraceDetails(trace),
+                `endpoint=${details.endpoint}`,
+                `model=${details.model || 'none'}`,
+                `prompt_tokens=${details.promptTokens ?? 'unknown'}`,
+                `prompt_count_source=${details.promptCountSource}`,
+                `max_input_tokens=${details.maxInputTokens}`,
+                `max_output_tokens=${details.maxOutputTokens}`,
+                `chosen_max_tokens=${details.chosenMaxTokens}`,
+                `safety_margin_tokens=${details.safetyMarginTokens}`,
+            ].join(' | ')
+        );
+    }
+
+    logBudgetFallback(
+        trace: RequestTraceContext,
+        details: {
+            endpoint: string;
+            model: string;
+            fallbackPromptTokens: number;
+            fallbackReason: string;
+        }
+    ) {
+        this.app.logger.addEventLog(
+            'BUDGET',
+            'EXACT_COUNT_FALLBACK',
+            [
+                this.formatTraceDetails(trace),
+                `endpoint=${details.endpoint}`,
+                `model=${details.model || 'none'}`,
+                `fallback_prompt_tokens=${details.fallbackPromptTokens}`,
+                `reason=${details.fallbackReason}`,
+            ].join(' | ')
+        );
+    }
+
+    async getToolsModelTokenLimits(): Promise<ResolvedModelTokenLimits> {
+        const { endpoint, model, requestConfig } = this.getToolsRequestDetails();
+        const cacheKey = [
+            endpoint,
+            model,
+            this.app.configuration.ai_api_version,
+            this.app.configuration.lm_max_input_tokens,
+            this.app.configuration.lm_max_output_tokens,
+        ].join('|');
+
+        if (this.toolsTokenLimitsCache
+            && this.toolsTokenLimitsCache.key === cacheKey
+            && this.toolsTokenLimitsCache.expiresAt > Date.now()) {
+            return this.toolsTokenLimitsCache.limits;
+        }
+
+        const configuredMaxInputTokens = this.app.configuration.lm_max_input_tokens;
+        const configuredMaxOutputTokens = this.app.configuration.lm_max_output_tokens;
+
+        const fallbackLimits = resolveModelTokenLimits(
+            { id: model || 'tools-model' },
+            {
+                configuredMaxInputTokens,
+                configuredMaxOutputTokens,
+            }
+        );
+
+        if (!endpoint) {
+            return fallbackLimits;
+        }
+
+        const modelsUrl = `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/models`;
+
+        try {
+            this.logApiRequest('TOOLS_MODELS', 'GET', modelsUrl, `model=${model || 'none'}`);
+            const response = await axios.get<OpenAIModelsResponse>(
+                modelsUrl,
+                requestConfig
+            );
+            this.logApiResponse('TOOLS_MODELS', 'GET', modelsUrl, `count=${response.data?.data?.length ?? 0}`);
+
+            const models = response.data?.data ?? [];
+            const matchedModel =
+                models.find((candidate) => candidate.id === model)
+                ?? (models.length === 1 ? models[0] : undefined);
+
+            if (!matchedModel) {
+                return fallbackLimits;
+            }
+
+            let runtimeContextSize: number | undefined;
+            if (configuredMaxInputTokens <= 0 && isLikelyLlamaCppProvider([matchedModel])) {
+                try {
+                    const propsUrl = models.length === 1
+                        ? buildRuntimePropsUrl(endpoint)
+                        : buildRuntimePropsUrl(endpoint, matchedModel.id);
+                    this.logApiRequest('TOOLS_PROPS', 'GET', propsUrl, `model=${matchedModel.id}`);
+                    const propsResponse = await axios.get(propsUrl, requestConfig);
+                    runtimeContextSize = extractRuntimeContextSize(propsResponse.data);
+                    this.logApiResponse('TOOLS_PROPS', 'GET', propsUrl, `n_ctx=${runtimeContextSize ?? 'unknown'}`);
+                } catch (error) {
+                    this.logApiError('TOOLS_PROPS', 'GET', models.length === 1 ? buildRuntimePropsUrl(endpoint) : buildRuntimePropsUrl(endpoint, matchedModel.id), error, `model=${matchedModel.id}`);
+                    runtimeContextSize = undefined;
+                }
+            }
+
+            const limits = resolveModelTokenLimits(matchedModel, {
+                configuredMaxInputTokens,
+                configuredMaxOutputTokens,
+                runtimeContextSize,
+            });
+
+            this.toolsTokenLimitsCache = {
+                key: cacheKey,
+                expiresAt: Date.now() + 30000,
+                limits,
+            };
+
+            return limits;
+        } catch (error) {
+            this.logApiError('TOOLS_MODELS', 'GET', modelsUrl, error, `model=${model || 'none'}`);
+            return fallbackLimits;
+        }
+    }
+
+    async applyToolsTemplate(
+        messages: ChatMessage[],
+        imagePath = "",
+        requestDetails?: RequestDetailsOverride
+    ): Promise<string | undefined> {
+        const { endpoint, model, requestConfig, trace, tools, toolChoice } = this.resolveRequestDetails(requestDetails);
+        if (!endpoint) {
+            return undefined;
+        }
+
+        const templateMessages = this.buildToolsMessages(messages, imagePath);
+        const templateUrl = `${Utils.trimTrailingSlash(endpoint)}/apply-template`;
+
+        try {
+            this.logApiRequest('APPLY_TEMPLATE', 'POST', templateUrl, `model=${model || 'none'} | ${this.summarizeTemplateMessages(templateMessages as unknown[])}`, trace);
+            const response = await axios.post<ApplyTemplateResponse>(
+                templateUrl,
+                {
+                    messages: templateMessages,
+                    ...(model.trim() !== '' && { model }),
+                    ...(tools?.length && { tools }),
+                    ...(toolChoice !== undefined && { tool_choice: toolChoice }),
+                },
+                requestConfig
+            );
+
+            this.logApiResponse('APPLY_TEMPLATE', 'POST', templateUrl, `prompt_length=${response.data.prompt?.length ?? 0}`, trace);
+
+            return response.status === STATUS_OK ? response.data.prompt : undefined;
+        } catch (error) {
+            const apiError = this.extractApiError(error);
+            const details = [
+                `endpoint=${endpoint}`,
+                `model=${model || 'none'}`,
+                this.summarizeTemplateMessages(templateMessages as unknown[]),
+                `error=${apiError.message.replace(/\r?\n/g, ' ')}`,
+            ].join(' | ');
+
+            this.logApiError('APPLY_TEMPLATE', 'POST', templateUrl, error, `model=${model || 'none'} | ${this.summarizeTemplateMessages(templateMessages as unknown[])}`, trace);
+            this.app.logger.addEventLog('TOOLS', 'APPLY_TEMPLATE_ERROR', details);
+            console.error('[llama-vscode] apply-template failed:', details);
+            return undefined;
+        }
+    }
+
+    async countToolsPromptTokens(
+        messages: ChatMessage[],
+        imagePath = "",
+        requestDetails?: RequestDetailsOverride
+    ): Promise<number | undefined> {
+        const prompt = await this.applyToolsTemplate(messages, imagePath, requestDetails);
+        if (!prompt) {
+            return undefined;
+        }
+
+        return this.countTextTokens(prompt, requestDetails);
+    }
+
+    async countTextTokens(text: string, requestDetails?: RequestDetailsOverride): Promise<number | undefined> {
+        const { endpoint, requestConfig, trace } = this.resolveRequestDetails(requestDetails);
+        if (!endpoint) {
+            return undefined;
+        }
+
+        const tokenizeUrl = `${Utils.trimTrailingSlash(endpoint)}/tokenize`;
+
+        try {
+            this.logApiRequest('TOKENIZE', 'POST', tokenizeUrl, `content_length=${text.length}`, trace);
+            const response = await axios.post<TokenizeResponse>(
+                tokenizeUrl,
+                {
+                    content: text,
+                    add_special: false,
+                    parse_special: true,
+                },
+                requestConfig
+            );
+
+            this.logApiResponse('TOKENIZE', 'POST', tokenizeUrl, `tokens=${response.data.tokens.length}`, trace);
+
+            return response.status === STATUS_OK ? response.data.tokens.length : undefined;
+        } catch (error) {
+            this.logApiError('TOKENIZE', 'POST', tokenizeUrl, error, `content_length=${text.length}`, trace);
+            return undefined;
+        }
+    }
+
+    estimateToolsRequestTokens(requestPayload: unknown): number {
+        // Fallback only: exact prompt counting should go through apply-template + tokenize.
+        return estimateTokenCount(requestPayload);
+    }
+
+    private createErrorResponse(error: LlamaApiError): LlamaToolsResponse {
+        return {
+            choices: [{
+                message: { content: error.message },
+                finish_reason: 'error',
+                error,
+            }],
+            error,
+        };
+    }
+
+    private extractApiError(error: unknown): LlamaApiError {
+        if (axios.isAxiosError(error)) {
+            const responseData = error.response?.data as { error?: LlamaApiError } | undefined;
+            if (responseData?.error) {
+                return responseData.error;
+            }
+
+            return {
+                message: error.message,
+                ...(typeof error.response?.status === 'number' && { status: error.response.status }),
+            };
+        }
+
+        if (error instanceof Error) {
+            return { message: error.message };
+        }
+
+        return { message: String(error) };
     }
 
 private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
@@ -336,11 +778,14 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             }
         }
 
+        const infillUrl = `${Utils.trimTrailingSlash(endpoint)}/infill`;
+        this.logApiRequest('FIM', 'POST', infillUrl, `model=${model || 'none'} | prompt_length=${prompt.length}`);
         const response = await axios.post<LlamaResponse>(
-            `${Utils.trimTrailingSlash(endpoint)}/infill`,
+            infillUrl,
             this.createRequestPayload(false, inputPrefix, inputSuffix, chunks, prompt, model, nindent),
             requestConfig
         );
+        this.logApiResponse('FIM', 'POST', infillUrl, `has_content=${response.data?.content !== undefined}`);
 
         return response.status === STATUS_OK ? response.data : undefined;
     };
@@ -355,11 +800,14 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
 
         let { endpoint, model, requestConfig } = this.getChatModelProperties();
 
+        const chatUrl = `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`;
+        this.logApiRequest('CHAT_EDIT', 'POST', chatUrl, `model=${model || 'none'}`);
         const response = await axios.post<LlamaChatResponse>(
-            `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`,
+            chatUrl,
             this.createChatEditRequestPayload(instructions, originalText, context, model),
             requestConfig
         );
+        this.logApiResponse('CHAT_EDIT', 'POST', chatUrl, `has_choices=${response.data?.choices?.length ?? 0}`);
 
         return response.status === STATUS_OK ? response.data : undefined;
     };
@@ -369,11 +817,14 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
     ): Promise<LlamaChatResponse | undefined> => {
         let { endpoint, model, requestConfig } = this.getChatModelProperties();
 
+        const chatUrl = `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`;
+        this.logApiRequest('CHAT', 'POST', chatUrl, `model=${model || 'none'} | prompt_length=${prompt.length}`);
         const response = await axios.post<LlamaChatResponse>(
-            `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`,
+            chatUrl,
             this.createChatRequestPayload(prompt, model),
             requestConfig
         );
+        this.logApiResponse('CHAT', 'POST', chatUrl, `has_choices=${response.data?.choices?.length ?? 0}`);
 
         return response.status === STATUS_OK ? response.data : undefined;
     };
@@ -383,45 +834,80 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
         isSummarization = false,
         onDelta?: (delta: string) => void,
         abortSignal?: AbortSignal,
-        imagePath = ""
+        imagePath = "",
+        trace: RequestTraceContext = this.createRequestTrace(isSummarization ? 'agent-summary' : 'agent')
     ): Promise<LlamaToolsResponse | undefined> => {
-        let selectedModel: LlmModel = this.app.getToolsModel();
-        let model = this.app.configuration.ai_model;
-        if (selectedModel?.aiModel !== undefined && selectedModel.aiModel) model = selectedModel.aiModel;
-
-        let endpoint = this.app.configuration.endpoint_tools;
-        if (selectedModel?.endpoint !== undefined && selectedModel.endpoint) endpoint = selectedModel.endpoint;
-
-        let requestConfig = this.app.configuration.axiosRequestConfigTools;
-        if (selectedModel?.isKeyRequired !== undefined && selectedModel.isKeyRequired){
-            const apiKey = this.app.persistence.getApiKey(selectedModel.endpoint??"");
-            if (apiKey){
-                requestConfig = {
-                    headers: {
-                        Authorization: `Bearer ${apiKey}`,
-                        "Content-Type": "application/json",
-                    },
-                }
-            }
-        }
+        const { endpoint, model, requestConfig } = this.getToolsRequestDetails();
 
         let uri = `${Utils.trimTrailingSlash(endpoint)}/${this.app.configuration.ai_api_version}/chat/completions`;
         let request: any;
 
         if (isSummarization) {
             request = this.createGetSummaryRequestPayload(messages, model);
-            const response = await axios.post<LlamaToolsResponse>(
-                uri,
-                request,
-                { ...requestConfig, signal: abortSignal }
-            );
-            return response.status === STATUS_OK ? response.data : undefined;
+            try {
+                this.logApiRequest('TOOLS_SUMMARY', 'POST', uri, `model=${model || 'none'} | ${this.summarizeTemplateMessages(request.messages as unknown[])}`, trace);
+                const response = await axios.post<LlamaToolsResponse>(
+                    uri,
+                    request,
+                    { ...requestConfig, signal: abortSignal }
+                );
+                this.logApiResponse('TOOLS_SUMMARY', 'POST', uri, `finish_reason=${response.data?.choices?.[0]?.finish_reason ?? 'unknown'}`, trace);
+                return response.status === STATUS_OK ? response.data : undefined;
+            } catch (error) {
+                this.logApiError('TOOLS_SUMMARY', 'POST', uri, error, `model=${model || 'none'}`, trace);
+                return this.createErrorResponse(this.extractApiError(error));
+            }
         }
 
         // Streaming branch for tools/agent calls
         request = this.createToolsRequestPayload(messages, model, true, imagePath);
+        const tokenLimits = await this.getToolsModelTokenLimits();
+        const exactPromptTokens = await this.countToolsPromptTokens(messages, imagePath, {
+            endpoint,
+            model,
+            requestConfig,
+            trace,
+        });
+        const promptTokenEstimate = exactPromptTokens ?? this.estimateToolsRequestTokens(request);
+        if (exactPromptTokens === undefined) {
+            this.logBudgetFallback(trace, {
+                endpoint,
+                model,
+                fallbackPromptTokens: promptTokenEstimate,
+                fallbackReason: 'exact_count_unavailable',
+            });
+        }
+        request.max_tokens = resolveRequestMaxOutputTokens({
+            maxInputTokens: tokenLimits.maxInputTokens,
+            maxOutputTokens: Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS),
+            promptTokenEstimate,
+            defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+            contextSafetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+        });
+        this.logBudgetDecision(trace, {
+            endpoint,
+            model,
+            promptTokens: promptTokenEstimate,
+            promptCountSource: exactPromptTokens === undefined ? 'fallback' : 'exact',
+            maxInputTokens: tokenLimits.maxInputTokens,
+            maxOutputTokens: Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS),
+            chosenMaxTokens: request.max_tokens as number,
+            safetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+        });
 
         try {
+            this.logApiRequest(
+                'TOOLS_STREAM',
+                'POST',
+                uri,
+                [
+                    `model=${model || 'none'}`,
+                    this.summarizeTemplateMessages(request.messages as unknown[]),
+                    `prompt_tokens=${promptTokenEstimate}`,
+                    `max_tokens=${request.max_tokens}`,
+                ].join(' | '),
+                trace
+            );
             const streamResponse = await axios.post<any>(
                 uri,
                 request,
@@ -435,15 +921,24 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                 let finishReason: string | undefined = undefined;
                 const toolCalls: any[] = [];
                 const message: any = { role: 'assistant', content: null as string | null };
+                let responseData: Partial<LlamaToolsResponse> = {};
 
                 const finalize = () => {
                     message.content = fullContent || null;
                     if (toolCalls.length > 0) message.tool_calls = toolCalls;
+                    this.logApiResponse(
+                        'TOOLS_STREAM',
+                        'POST',
+                        uri,
+                        `finish_reason=${finishReason ?? 'unknown'} | truncated=${responseData.truncated === true} | content_length=${fullContent.length} | tool_calls=${toolCalls.length}`,
+                        trace
+                    );
                     resolve({
                         choices: [{
                             message,
                             finish_reason: finishReason,
-                        }]
+                        }],
+                        ...responseData,
                     });
                 };
 
@@ -473,6 +968,12 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                             const json = JSON.parse(payload);
                             const choice = json.choices && json.choices[0] ? json.choices[0] : undefined;
                             if (!choice) continue;
+
+                            if (typeof json.truncated === 'boolean') responseData.truncated = json.truncated;
+                            if (typeof json.tokens_cached === 'number') responseData.tokens_cached = json.tokens_cached;
+                            if (json.timings) responseData.timings = json.timings;
+                            if (json.generation_settings) responseData.generation_settings = json.generation_settings;
+                            if (json.usage) responseData.usage = json.usage;
 
                             // Finish reason may appear on a later chunk
                             if (choice.finish_reason) finishReason = choice.finish_reason;
@@ -511,11 +1012,13 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                 });
 
                 readable.on('error', () => {
-                    resolve(undefined);
+                    this.logApiError('TOOLS_STREAM', 'POST', uri, { message: 'Stream error during generation' }, `model=${model || 'none'}`, trace);
+                    resolve(this.createErrorResponse({ message: 'Stream error during generation' }));
                 });
             });
         } catch (err) {
-            return undefined;
+            this.logApiError('TOOLS_STREAM', 'POST', uri, err, `model=${model || 'none'}`, trace);
+            return this.createErrorResponse(this.extractApiError(err));
         }
     };
 
@@ -529,20 +1032,26 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
 
         // else, make a request to the API to prepare for the next FIM
         let { endpoint, model, requestConfig } = this.getComplModelProperties();
+        const infillUrl = `${Utils.trimTrailingSlash(endpoint)}/infill`;
+        this.logApiRequest('FIM_PREP', 'POST', infillUrl, `model=${model || 'none'} | chunks=${chunks.length ?? 0}`);
         axios.post<LlamaResponse>(
-            `${Utils.trimTrailingSlash(endpoint)}/infill`,
+            infillUrl,
             this.createRequestPayload(true, "", "", chunks, "", model, undefined),
             requestConfig
-        );
+        ).then(() => {
+            this.logApiResponse('FIM_PREP', 'POST', infillUrl, 'ok');
+        }).catch((error) => {
+            this.logApiError('FIM_PREP', 'POST', infillUrl, error, `model=${model || 'none'}`);
+        });
     };
 
     getEmbeddings = async (text: string): Promise<LlamaEmbeddingsResponse | undefined> => {
+        let endpoint = this.app.configuration.endpoint_embeddings;
+        let model = this.app.configuration.ai_model;
         try {
             let selectedModel: LlmModel = this.app.getEmbeddingsModel();
-            let model = this.app.configuration.ai_model;
             if (selectedModel.aiModel) model = selectedModel.aiModel;
 
-            let endpoint = this.app.configuration.endpoint_embeddings;
             if (selectedModel.endpoint) endpoint = selectedModel.endpoint;
 
             let requestConfig = this.app.configuration.axiosRequestConfigEmbeddings;
@@ -558,8 +1067,10 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                 }
             }
 
+            const embeddingsUrl = `${Utils.trimTrailingSlash(endpoint)}/v1/embeddings`;
+            this.logApiRequest('EMBEDDINGS', 'POST', embeddingsUrl, `model=${model || 'none'} | input_length=${text.length}`);
             const response = await axios.post<LlamaEmbeddingsResponse>(
-                `${Utils.trimTrailingSlash(endpoint)}/v1/embeddings`,
+                embeddingsUrl,
                 {
                     "input": text,
                     // "model": "GPT-4",
@@ -568,8 +1079,10 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                 },
                 requestConfig
             );
+            this.logApiResponse('EMBEDDINGS', 'POST', embeddingsUrl, `tokens=${response.data.usage?.total_tokens ?? 'unknown'}`);
             return response.data;
         } catch (error: any) {
+            this.logApiError('EMBEDDINGS', 'POST', `${Utils.trimTrailingSlash(endpoint)}/v1/embeddings`, error, `model=${model || 'none'}`);
             console.error('Failed to get embeddings:', error);
             vscode.window.showInformationMessage(this.app.configuration.getUiText("Error getting embeddings") + " " + error.message);
             return undefined;
@@ -852,10 +1365,14 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
         }
         try {
             // TODO:Make sure to work with OpenRauter too
-            let response = await axios.get(model.endpoint + "/health", requestConfig);
+            const healthUrl = model.endpoint + "/health";
+            this.logApiRequest('HEALTH', 'GET', healthUrl, `modelType=${modelType}`);
+            let response = await axios.get(healthUrl, requestConfig);
+            this.logApiResponse('HEALTH', 'GET', healthUrl, `status=${response.data?.status ?? 'missing'}`);
             if (!response.data.hasOwnProperty("status")) return "Error: No health status field found";
             return response.data.status
         } catch (error) {
+            this.logApiError('HEALTH', 'GET', model.endpoint + "/health", error, `modelType=${modelType}`);
             if (error instanceof TypeError) {
                 return "TypeError occurred: " + error.message;
             } else if (error instanceof ReferenceError) {

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -459,6 +459,30 @@ export class LlamaServer {
         this.app.logger.addEventLog('API', `${label}_${method}_RESPONSE`, [url, this.formatTraceDetails(trace), details].filter(Boolean).join(' | '));
     }
 
+    private formatUsageLogDetails(usage: Record<string, unknown> | undefined, tokensCached?: number): string[] {
+        const completionTokenDetails = this.getUsageRecordField(usage, 'completion_tokens_details');
+        const promptTokenDetails = this.getUsageRecordField(usage, 'prompt_tokens_details');
+        const cachedPromptTokens = this.getUsageNumberField(promptTokenDetails, 'cached_tokens');
+
+        return [
+            `prompt_tokens=${this.getUsageNumberField(usage, 'prompt_tokens') ?? 'unknown'}`,
+            `completion_tokens=${this.getUsageNumberField(usage, 'completion_tokens') ?? 'unknown'}`,
+            `total_tokens=${this.getUsageNumberField(usage, 'total_tokens') ?? 'unknown'}`,
+            `reasoning_tokens=${this.getUsageNumberField(completionTokenDetails, 'reasoning_tokens') ?? 'unknown'}`,
+            `cached_prompt_tokens=${cachedPromptTokens ?? tokensCached ?? 'unknown'}`,
+        ];
+    }
+
+    private getUsageRecordField(record: Record<string, unknown> | undefined, field: string): Record<string, unknown> | undefined {
+        const value = record?.[field];
+        return value && typeof value === 'object' ? value as Record<string, unknown> : undefined;
+    }
+
+    private getUsageNumberField(record: Record<string, unknown> | undefined, field: string): number | undefined {
+        const value = record?.[field];
+        return typeof value === 'number' ? value : undefined;
+    }
+
     private logApiError(label: string, method: string, url: string, error: unknown, details = "", trace?: RequestTraceContext) {
         const apiError = this.extractApiError(error);
         this.app.logger.addEventLog(
@@ -936,7 +960,13 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                         'TOOLS_STREAM',
                         'POST',
                         uri,
-                        `finish_reason=${finishReason ?? 'unknown'} | truncated=${responseData.truncated === true} | content_length=${fullContent.length} | tool_calls=${toolCalls.length}`,
+                        [
+                            `finish_reason=${finishReason ?? 'unknown'}`,
+                            `truncated=${responseData.truncated === true}`,
+                            `content_length=${fullContent.length}`,
+                            `tool_calls=${toolCalls.length}`,
+                            ...this.formatUsageLogDetails(responseData.usage as Record<string, unknown> | undefined, responseData.tokens_cached),
+                        ].join(' | '),
                         trace
                     );
                     resolve({

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -17,6 +17,7 @@ import {
     isLikelyLlamaCppProvider,
     OpenAICompatibleModel,
     resolveModelTokenLimits,
+    resolveBoundedMaxOutputTokens,
     resolveRequestMaxOutputTokens,
     ResolvedModelTokenLimits,
 } from './language-model-token-limits';
@@ -877,9 +878,14 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
                 fallbackReason: 'exact_count_unavailable',
             });
         }
+        const boundedMaxOutputTokens = resolveBoundedMaxOutputTokens({
+            maxInputTokens: tokenLimits.maxInputTokens,
+            maxOutputTokens: tokenLimits.maxOutputTokens,
+            defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        });
         request.max_tokens = resolveRequestMaxOutputTokens({
             maxInputTokens: tokenLimits.maxInputTokens,
-            maxOutputTokens: Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS),
+            maxOutputTokens: boundedMaxOutputTokens,
             promptTokenEstimate,
             defaultMaxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
             contextSafetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
@@ -890,7 +896,7 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             promptTokens: promptTokenEstimate,
             promptCountSource: exactPromptTokens === undefined ? 'fallback' : 'exact',
             maxInputTokens: tokenLimits.maxInputTokens,
-            maxOutputTokens: Math.min(tokenLimits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS),
+            maxOutputTokens: boundedMaxOutputTokens,
             chosenMaxTokens: request.max_tokens as number,
             safetyMarginTokens: DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
         });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,17 +1,26 @@
+import * as vscode from 'vscode';
 import {Application} from "./application";
 
 export class Logger {
     private app: Application
+    private readonly outputChannel: vscode.OutputChannel
     eventlogs: string[] = []
 
     constructor(application: Application) {
         this.app = application;
+        this.outputChannel = vscode.window.createOutputChannel('llama-vscode');
     }
 
     addEventLog = (group: string, event: string, details: string) => {
-        this.eventlogs.push(Date.now() + ", " + group + ", " + event + ", " + details.replace(",", " "));
+        const logEntry = Date.now() + ", " + group + ", " + event + ", " + details.replace(",", " ");
+        this.eventlogs.push(logEntry);
+        this.outputChannel.appendLine(logEntry);
         if (this.eventlogs.length > this.app.configuration.MAX_EVENTS_IN_LOG) {
             this.eventlogs.shift();
         }
+    }
+
+    show = () => {
+        this.outputChannel.show(true);
     }
 }

--- a/src/services/env-service.ts
+++ b/src/services/env-service.ts
@@ -176,6 +176,9 @@ export class EnvService {
                 await this.app.modelService.addApiKey(toolsModel);
                 if (toolsModel.localStartCommand) {
                     await this.app.llamaServer.shellToolsCmd(this.app.modelService.sanitizeCommand(toolsModel.localStartCommand));
+                    // Loading can change what /v1/models and /props report for the selected
+                    // model, so fire another refresh after the server is actually running.
+                    this.app.llamaChatModelProvider.notifyModelsChanged();
                 }
             }
 

--- a/src/services/model-service.ts
+++ b/src/services/model-service.ts
@@ -195,6 +195,9 @@ export class ModelService {
         await details.killCmd();
         if (model.localStartCommand) await details.shellCmd(this.sanitizeCommand(model.localStartCommand ?? ""));
         await this.app.persistence.setValue(this.getSelectedProp(type), model);
+        if (type === ModelType.Tools) {
+            this.app.llamaChatModelProvider.notifyModelsChanged();
+        }
         if (type == ModelType.Tools && model?.isKeyRequired !== undefined && model.isKeyRequired){
             const apiKey = this.app.persistence.getApiKey(model.endpoint??"");
             if (apiKey){

--- a/src/test/suite/language-model-token-limits.test.ts
+++ b/src/test/suite/language-model-token-limits.test.ts
@@ -10,6 +10,7 @@ import {
     extractRuntimeContextSize,
     isLikelyLlamaCppProvider,
     resolveBoundedMaxOutputTokens,
+    resolvePublishedModelTokenLimits,
     resolveRequestMaxOutputTokens,
     resolveModelTokenLimits,
 } from '../../language-model-token-limits';
@@ -50,6 +51,37 @@ suite('Language Model Token Limits Test Suite', () => {
         assert.strictEqual(runtimeContextSize, 262144);
         assert.strictEqual(limits.maxInputTokens, 262144);
         assert.strictEqual(limits.maxOutputTokens, 262144);
+    });
+
+    test('publishes shared-context llama.cpp limits as a prompt and output partition', () => {
+        const limits = resolvePublishedModelTokenLimits(
+            {
+                id: 'gemma-3',
+                owned_by: 'llamacpp',
+            },
+            {
+                runtimeContextSize: 65536,
+            }
+        );
+
+        assert.strictEqual(limits.maxInputTokens, 49152);
+        assert.strictEqual(limits.maxOutputTokens, 16384);
+    });
+
+    test('publishes configured llama.cpp output overrides within the same total context window', () => {
+        const limits = resolvePublishedModelTokenLimits(
+            {
+                id: 'gemma-3',
+                owned_by: 'llamacpp',
+            },
+            {
+                runtimeContextSize: 65536,
+                configuredMaxOutputTokens: 8192,
+            }
+        );
+
+        assert.strictEqual(limits.maxInputTokens, 57344);
+        assert.strictEqual(limits.maxOutputTokens, 8192);
     });
 
     test('honors explicit overrides and detects model output limits', () => {

--- a/src/test/suite/language-model-token-limits.test.ts
+++ b/src/test/suite/language-model-token-limits.test.ts
@@ -1,0 +1,143 @@
+/// <reference types="mocha" />
+import * as assert from 'assert';
+import { suite, test } from 'mocha';
+import {
+    DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS,
+    buildRuntimePropsUrl,
+    DEFAULT_MAX_INPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    estimateTokenCount,
+    extractRuntimeContextSize,
+    isLikelyLlamaCppProvider,
+    resolveRequestMaxOutputTokens,
+    resolveModelTokenLimits,
+} from '../../language-model-token-limits';
+
+suite('Language Model Token Limits Test Suite', () => {
+    test('uses llama.cpp metadata context length for both input and output defaults', () => {
+        const limits = resolveModelTokenLimits({
+            id: 'gemma-3',
+            meta: {
+                n_ctx_train: 131072,
+            },
+        });
+
+        assert.strictEqual(limits.maxInputTokens, 131072);
+        assert.strictEqual(limits.maxOutputTokens, 131072);
+    });
+
+    test('prefers runtime llama.cpp context for both input and output defaults', () => {
+        const runtimeContextSize = extractRuntimeContextSize({
+            default_generation_settings: {
+                n_ctx: 262144,
+            },
+        });
+
+        const limits = resolveModelTokenLimits(
+            {
+                id: 'gemma-3',
+                meta: {
+                    n_ctx_train: 131072,
+                },
+            },
+            {
+                configuredMaxInputTokens: 0,
+                runtimeContextSize,
+            }
+        );
+
+        assert.strictEqual(runtimeContextSize, 262144);
+        assert.strictEqual(limits.maxInputTokens, 262144);
+        assert.strictEqual(limits.maxOutputTokens, 262144);
+    });
+
+    test('honors explicit overrides and detects model output limits', () => {
+        const limits = resolveModelTokenLimits(
+            {
+                id: 'provider-model',
+                context_length: '64000',
+                top_provider: {
+                    max_completion_tokens: '12000',
+                },
+            },
+            {
+                configuredMaxInputTokens: 128000,
+                configuredMaxOutputTokens: 0,
+            }
+        );
+
+        assert.strictEqual(limits.maxInputTokens, 128000);
+        assert.strictEqual(limits.maxOutputTokens, 12000);
+    });
+
+    test('falls back to defaults when nothing is reported', () => {
+        const limits = resolveModelTokenLimits(
+            {
+                id: 'unknown-model',
+            },
+            {
+                configuredMaxInputTokens: 0,
+                configuredMaxOutputTokens: 0,
+            }
+        );
+
+        assert.strictEqual(limits.maxInputTokens, DEFAULT_MAX_INPUT_TOKENS);
+        assert.strictEqual(limits.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+
+    test('detects llama.cpp provider model metadata', () => {
+        assert.strictEqual(
+            isLikelyLlamaCppProvider([
+                {
+                    id: 'gemma-router-model',
+                    owned_by: 'llamacpp',
+                },
+            ]),
+            true
+        );
+    });
+
+    test('builds router props url with autoload disabled', () => {
+        const url = buildRuntimePropsUrl('http://127.0.0.1:8080/v1/', 'ggml-org/gemma-3-4b-it-GGUF:Q4_K_M');
+
+        assert.strictEqual(
+            url,
+            'http://127.0.0.1:8080/v1/props?model=ggml-org%2Fgemma-3-4b-it-GGUF%3AQ4_K_M&autoload=false'
+        );
+    });
+
+    test('clamps output tokens to remaining context budget', () => {
+        const maxTokens = resolveRequestMaxOutputTokens({
+            maxInputTokens: 65536,
+            maxOutputTokens: 65536,
+            promptTokenEstimate: 58000,
+        });
+
+        assert.strictEqual(
+            maxTokens,
+            65536 - 58000 - DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS
+        );
+    });
+
+    test('falls back to one token when prompt already fills the context window', () => {
+        const maxTokens = resolveRequestMaxOutputTokens({
+            maxInputTokens: 8192,
+            maxOutputTokens: 4096,
+            promptTokenEstimate: 8192,
+        });
+
+        assert.strictEqual(maxTokens, 1);
+    });
+
+    test('estimates token counts for structured payloads', () => {
+        const estimatedTokens = estimateTokenCount({
+            messages: [
+                { role: 'assistant', content: 'hello world' },
+                { role: 'tool', content: 'tool output' },
+            ],
+            tools: [{ type: 'function', function: { name: 'read_file' } }],
+        });
+
+        assert.ok(estimatedTokens > 0);
+    });
+});

--- a/src/test/suite/language-model-token-limits.test.ts
+++ b/src/test/suite/language-model-token-limits.test.ts
@@ -9,6 +9,7 @@ import {
     estimateTokenCount,
     extractRuntimeContextSize,
     isLikelyLlamaCppProvider,
+    resolveBoundedMaxOutputTokens,
     resolveRequestMaxOutputTokens,
     resolveModelTokenLimits,
 } from '../../language-model-token-limits';
@@ -127,6 +128,25 @@ suite('Language Model Token Limits Test Suite', () => {
         });
 
         assert.strictEqual(maxTokens, 1);
+    });
+
+    test('caps requested output tokens to one quarter of the context window', () => {
+        const maxTokens = resolveBoundedMaxOutputTokens({
+            maxInputTokens: 65536,
+            maxOutputTokens: 65536,
+        });
+
+        assert.strictEqual(maxTokens, 16384);
+    });
+
+    test('applies the quarter-window cap before remaining-context clamping', () => {
+        const maxTokens = resolveRequestMaxOutputTokens({
+            maxInputTokens: 65536,
+            maxOutputTokens: 65536,
+            promptTokenEstimate: 23000,
+        });
+
+        assert.strictEqual(maxTokens, 16384);
     });
 
     test('estimates token counts for structured payloads', () => {

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -258,6 +258,7 @@ suite('LlamaChatModelProvider Test Suite', () => {
 				assert.ok(error instanceof Error);
 				assert.strictEqual(error.name, 'LanguageModelProviderError');
 				assert.match(error.message, /empty response/i);
+				assert.strictEqual(error.stack, undefined);
 				return true;
 			}
 		);

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="mocha" />
 import * as assert from 'assert';
+import { Readable } from 'stream';
 import * as vscode from 'vscode';
 import axios from 'axios';
 import { suite, test, teardown } from 'mocha';
@@ -124,5 +125,141 @@ suite('LlamaChatModelProvider Test Suite', () => {
 		);
 
 		assert.strictEqual(postCalled, false);
+	});
+
+	test('flushes the final SSE chunk when the stream ends without a trailing newline', async () => {
+		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+			if (url.endsWith('/v1/models')) {
+				return {
+					data: {
+						data: [
+							{
+								id: 'mock-model',
+								owned_by: 'llamacpp',
+							},
+						],
+					},
+				};
+			}
+
+			if (url.includes('/props')) {
+				return {
+					data: {
+						default_generation_settings: {
+							n_ctx: 65536,
+						},
+					},
+				};
+			}
+
+			throw new Error(`Unexpected GET ${url}`);
+		}) as typeof axios.get;
+
+		(axios as typeof axios & { post: typeof axios.post }).post = (async () => ({
+			data: Readable.from([
+				'data: {"choices":[{"delta":{"content":"final answer"}}]}'
+			]),
+		})) as typeof axios.post;
+
+		const provider = new LlamaChatModelProvider(new MockApplication() as unknown as Application);
+		const reportedParts: vscode.LanguageModelResponsePart[] = [];
+
+		await provider.provideLanguageModelChatResponse(
+			{
+				id: 'mock-model',
+				name: 'mock-model',
+				family: 'llama-vscode',
+				version: '1',
+				maxInputTokens: 65536,
+				maxOutputTokens: 4096,
+				capabilities: {
+					toolCalling: true,
+					imageInput: false,
+				},
+			},
+			[
+				{
+					role: vscode.LanguageModelChatMessageRole.User,
+					content: [new vscode.LanguageModelTextPart('say hello')],
+				},
+			] as unknown as readonly vscode.LanguageModelChatRequestMessage[],
+			{} as vscode.ProvideLanguageModelChatResponseOptions,
+			{ report: part => reportedParts.push(part) },
+			new vscode.CancellationTokenSource().token,
+		);
+
+		assert.deepStrictEqual(
+			reportedParts.map(part => part instanceof vscode.LanguageModelTextPart ? part.value : part.constructor.name),
+			['final answer']
+		);
+	});
+
+	test('rejects an empty streamed response explicitly', async () => {
+		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+			if (url.endsWith('/v1/models')) {
+				return {
+					data: {
+						data: [
+							{
+								id: 'mock-model',
+								owned_by: 'llamacpp',
+							},
+						],
+					},
+				};
+			}
+
+			if (url.includes('/props')) {
+				return {
+					data: {
+						default_generation_settings: {
+							n_ctx: 65536,
+						},
+					},
+				};
+			}
+
+			throw new Error(`Unexpected GET ${url}`);
+		}) as typeof axios.get;
+
+		(axios as typeof axios & { post: typeof axios.post }).post = (async () => ({
+			data: Readable.from([
+				'data: {"choices":[{"delta":{}}]}\n'
+			]),
+		})) as typeof axios.post;
+
+		const provider = new LlamaChatModelProvider(new MockApplication() as unknown as Application);
+
+		await assert.rejects(
+			() => provider.provideLanguageModelChatResponse(
+				{
+					id: 'mock-model',
+					name: 'mock-model',
+					family: 'llama-vscode',
+					version: '1',
+					maxInputTokens: 65536,
+					maxOutputTokens: 4096,
+					capabilities: {
+						toolCalling: true,
+						imageInput: false,
+					},
+				},
+				[
+					{
+						role: vscode.LanguageModelChatMessageRole.User,
+						content: [new vscode.LanguageModelTextPart('say hello')],
+					},
+				] as unknown as readonly vscode.LanguageModelChatRequestMessage[],
+				{} as vscode.ProvideLanguageModelChatResponseOptions,
+				{ report: () => undefined },
+				new vscode.CancellationTokenSource().token,
+			),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.strictEqual(error.name, 'LanguageModelProviderError');
+				assert.match(error.message, /empty response/i);
+				return true;
+			}
+		);
 	});
 });

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="mocha" />
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import axios from 'axios';
+import { suite, test, teardown } from 'mocha';
+import { LlamaChatModelProvider } from '../../llama-chat-model-provider';
+import { Application } from '../../application';
+
+class MockApplication {
+	configuration = {
+		ai_api_version: 'v1',
+		lm_max_input_tokens: 0,
+		lm_max_output_tokens: 0,
+		endpoint_chat: 'http://127.0.0.1:8080',
+		endpoint_tools: '',
+		axiosRequestConfigChat: {},
+		axiosRequestConfigTools: {},
+	};
+
+	persistence = {
+		getApiKey: () => undefined,
+	};
+
+	logger = {
+		addEventLog: () => undefined,
+	};
+
+	llamaServer = {
+		createRequestTrace: (caller: string) => ({
+			requestId: 'test-request-id',
+			caller,
+		}),
+		countToolsPromptTokens: async () => 33135,
+		logBudgetDecision: () => undefined,
+		logBudgetFallback: () => undefined,
+	};
+
+	getToolsModel() {
+		return undefined;
+	}
+}
+
+suite('LlamaChatModelProvider Test Suite', () => {
+	const originalGet = axios.get;
+	const originalPost = axios.post;
+
+	teardown(() => {
+		(axios as typeof axios & { get: typeof axios.get }).get = originalGet;
+		(axios as typeof axios & { post: typeof axios.post }).post = originalPost;
+	});
+
+	test('rejects exact prompt overflow before sending chat completions', async () => {
+		let postCalled = false;
+
+		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+			if (url.endsWith('/v1/models')) {
+				return {
+					data: {
+						data: [
+							{
+								id: 'mock-model',
+								owned_by: 'llamacpp',
+							},
+						],
+					},
+				};
+			}
+
+			if (url.includes('/props')) {
+				return {
+					data: {
+						default_generation_settings: {
+							n_ctx: 32768,
+						},
+					},
+				};
+			}
+
+			throw new Error(`Unexpected GET ${url}`);
+		}) as typeof axios.get;
+
+		(axios as typeof axios & { post: typeof axios.post }).post = (async () => {
+			postCalled = true;
+			throw new Error('chat completions should not be called when the prompt already exceeds context');
+		}) as typeof axios.post;
+
+		const provider = new LlamaChatModelProvider(new MockApplication() as unknown as Application);
+		const model: vscode.LanguageModelChatInformation = {
+			id: 'mock-model',
+			name: 'mock-model',
+			family: 'llama-vscode',
+			version: '1',
+			maxInputTokens: 32768,
+			maxOutputTokens: 4096,
+			capabilities: {
+				toolCalling: true,
+				imageInput: false,
+			},
+		};
+		const messages = [
+			{
+				role: vscode.LanguageModelChatMessageRole.User,
+				content: [new vscode.LanguageModelTextPart('is it faster than ansible?')],
+			},
+		] as unknown as readonly vscode.LanguageModelChatRequestMessage[];
+
+		await assert.rejects(
+			() => provider.provideLanguageModelChatResponse(
+				model,
+				messages,
+				{} as vscode.ProvideLanguageModelChatResponseOptions,
+				{ report: () => undefined },
+				new vscode.CancellationTokenSource().token,
+			),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.strictEqual(error.name, 'LanguageModelProviderError');
+				assert.match(error.message, /exceeds the model context window/i);
+				assert.match(error.message, /33135/);
+				assert.match(error.message, /32768/);
+				assert.strictEqual(error.stack, undefined);
+				return true;
+			}
+		);
+
+		assert.strictEqual(postCalled, false);
+	});
+});

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -131,6 +131,59 @@ suite('LlamaChatModelProvider Test Suite', () => {
 		assert.strictEqual(postCalled, false);
 	});
 
+		test('publishes llama.cpp runtime context as a shared prompt and output budget', async () => {
+			(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+				if (url.endsWith('/v1/models')) {
+					return {
+						data: {
+							data: [
+								{
+									id: 'mock-model',
+									owned_by: 'llamacpp',
+									meta: {
+										n_ctx_train: 131072,
+									},
+								},
+							],
+						},
+					};
+				}
+
+				if (url.includes('/props')) {
+					return {
+						data: {
+							default_generation_settings: {
+								n_ctx: 65536,
+							},
+						},
+					};
+				}
+
+				throw new Error(`Unexpected GET ${url}`);
+			}) as typeof axios.get;
+
+			const provider = new LlamaChatModelProvider(new MockApplication() as unknown as Application);
+			const models = await provider.provideLanguageModelChatInformation(
+				{} as vscode.PrepareLanguageModelChatModelOptions,
+				new vscode.CancellationTokenSource().token,
+			);
+
+			assert.deepStrictEqual(models, [
+				{
+					id: 'mock-model',
+					name: 'mock-model',
+					family: 'llama-vscode',
+					version: '1',
+					maxInputTokens: 49152,
+					maxOutputTokens: 16384,
+					capabilities: {
+						toolCalling: true,
+						imageInput: false,
+					},
+				},
+			]);
+		});
+
 	test('flushes the final SSE chunk when the stream ends without a trailing newline', async () => {
 		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
 			if (url.endsWith('/v1/models')) {

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -263,4 +263,76 @@ suite('LlamaChatModelProvider Test Suite', () => {
 			}
 		);
 	});
+
+	test('rejects reasoning-only streamed responses that exhaust the output budget', async () => {
+		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+			if (url.endsWith('/v1/models')) {
+				return {
+					data: {
+						data: [
+							{
+								id: 'mock-model',
+								owned_by: 'llamacpp',
+							},
+						],
+					},
+				};
+			}
+
+			if (url.includes('/props')) {
+				return {
+					data: {
+						default_generation_settings: {
+							n_ctx: 65536,
+						},
+					},
+				};
+			}
+
+			throw new Error(`Unexpected GET ${url}`);
+		}) as typeof axios.get;
+
+		(axios as typeof axios & { post: typeof axios.post }).post = (async () => ({
+			data: Readable.from([
+				'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n',
+				'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n',
+				'data: [DONE]\n'
+			]),
+		})) as typeof axios.post;
+
+		const provider = new LlamaChatModelProvider(new MockApplication() as unknown as Application);
+
+		await assert.rejects(
+			() => provider.provideLanguageModelChatResponse(
+				{
+					id: 'mock-model',
+					name: 'mock-model',
+					family: 'llama-vscode',
+					version: '1',
+					maxInputTokens: 65536,
+					maxOutputTokens: 4096,
+					capabilities: {
+						toolCalling: true,
+						imageInput: false,
+					},
+				},
+				[
+					{
+						role: vscode.LanguageModelChatMessageRole.User,
+						content: [new vscode.LanguageModelTextPart('say hello')],
+					},
+				] as unknown as readonly vscode.LanguageModelChatRequestMessage[],
+				{} as vscode.ProvideLanguageModelChatResponseOptions,
+				{ report: () => undefined },
+				new vscode.CancellationTokenSource().token,
+			),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.strictEqual(error.name, 'LanguageModelProviderError');
+				assert.match(error.message, /entire output budget on internal reasoning/i);
+				assert.strictEqual(error.stack, undefined);
+				return true;
+			}
+		);
+	});
 });

--- a/src/test/suite/llama-chat-model-provider.test.ts
+++ b/src/test/suite/llama-chat-model-provider.test.ts
@@ -8,6 +8,8 @@ import { LlamaChatModelProvider } from '../../llama-chat-model-provider';
 import { Application } from '../../application';
 
 class MockApplication {
+	eventLogs: string[] = [];
+
 	configuration = {
 		ai_api_version: 'v1',
 		lm_max_input_tokens: 0,
@@ -23,7 +25,9 @@ class MockApplication {
 	};
 
 	logger = {
-		addEventLog: () => undefined,
+		addEventLog: (group: string, event: string, details: string) => {
+			this.eventLogs.push([group, event, details].join(' | '));
+		},
 	};
 
 	llamaServer = {
@@ -192,6 +196,78 @@ suite('LlamaChatModelProvider Test Suite', () => {
 			reportedParts.map(part => part instanceof vscode.LanguageModelTextPart ? part.value : part.constructor.name),
 			['final answer']
 		);
+	});
+
+	test('logs per-turn usage from a usage-only final SSE chunk', async () => {
+		(axios as typeof axios & { get: typeof axios.get }).get = (async (url: string) => {
+			if (url.endsWith('/v1/models')) {
+				return {
+					data: {
+						data: [
+							{
+								id: 'mock-model',
+								owned_by: 'llamacpp',
+							},
+						],
+					},
+				};
+			}
+
+			if (url.includes('/props')) {
+				return {
+					data: {
+						default_generation_settings: {
+							n_ctx: 65536,
+						},
+					},
+				};
+			}
+
+			throw new Error(`Unexpected GET ${url}`);
+		}) as typeof axios.get;
+
+		(axios as typeof axios & { post: typeof axios.post }).post = (async () => ({
+			data: Readable.from([
+				'data: {"choices":[{"delta":{"content":"final answer"}}]}\n',
+				'data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"completion_tokens_details":{"reasoning_tokens":20},"prompt_tokens_details":{"cached_tokens":7}}}\n',
+				'data: [DONE]\n'
+			]),
+		})) as typeof axios.post;
+
+		const app = new MockApplication();
+		const provider = new LlamaChatModelProvider(app as unknown as Application);
+
+		await provider.provideLanguageModelChatResponse(
+			{
+				id: 'mock-model',
+				name: 'mock-model',
+				family: 'llama-vscode',
+				version: '1',
+				maxInputTokens: 65536,
+				maxOutputTokens: 4096,
+				capabilities: {
+					toolCalling: true,
+					imageInput: false,
+				},
+			},
+			[
+				{
+					role: vscode.LanguageModelChatMessageRole.User,
+					content: [new vscode.LanguageModelTextPart('say hello')],
+				},
+			] as unknown as readonly vscode.LanguageModelChatRequestMessage[],
+			{} as vscode.ProvideLanguageModelChatResponseOptions,
+			{ report: () => undefined },
+			new vscode.CancellationTokenSource().token,
+		);
+
+		const usageLog = app.eventLogs.find(entry => entry.includes('CHAT_COMPLETIONS_POST_RESPONSE'));
+		assert.ok(usageLog);
+		assert.match(usageLog!, /prompt_tokens=100/);
+		assert.match(usageLog!, /completion_tokens=50/);
+		assert.match(usageLog!, /total_tokens=150/);
+		assert.match(usageLog!, /reasoning_tokens=20/);
+		assert.match(usageLog!, /cached_prompt_tokens=7/);
 	});
 
 	test('rejects an empty streamed response explicitly', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
 	"compilerOptions": {
 	  "target": "ES2020",
 	  "module": "commonjs",
+	  "rootDir": "src",
 	  "outDir": "dist",
 	  "lib": ["ES2020", "DOM"],
+	  "types": ["node", "vscode"],
 	  "strict": true,
 	  "moduleResolution": "node",
+	  "ignoreDeprecations": "6.0",
 	  "sourceMap": true,
 	  "resolveJsonModule": true,
 	  "esModuleInterop": true


### PR DESCRIPTION
**UPDATE: PLEASE SEE COMMENTS.** This PR fixes the first set of bugs I encountered with context window management and greatly improves behavior. I think it should still be merged as a near-term improvement, both because it materially improves the extension already and because it enables more real-world use and testing. However, this PR does not fully solve context window management. In the comments, I outline what the full fix needs to include. Ultimately, the correct solution is for llama-server to expose authoritative context-budget information, and for llama.vscode to consume that data consistently across both the VS Code LM provider path and the extension’s own agent/chat path. That would move context management from heuristic estimation to server-driven correctness.

Original Description:

For llama.cpp-backed chat models, llama-vscode always fell back to reporting an 8K input / 4K output token budget to VS Code instead of the actual runtime context supported by the model. In practice, this made the VS Code model picker and chat model selector display an initial 12K context window even when the underlying llama.cpp runtime context was much larger.

With auto-summarization enabled, VS Code then compacted chat history too early, which degraded agent sessions and in some cases could prevent the first full response from being generated.

## What changed

- Add token-limit resolution logic for VS Code LM chat models
- Detect input/output token limits from:
  - explicit user overrides
  - model metadata
  - llama.cpp runtime properties
- Publish those resolved values through `LanguageModelChatInformation`
- Add settings for explicit token-limit overrides:
  - `llama-vscode.lm_max_input_tokens`
  - `llama-vscode.lm_max_output_tokens`
- Add tests covering token-limit resolution behavior
- Update the LM typing shim to match the current VS Code typing model used
  by this branch

## Why this is needed

The previous fallback values caused VS Code to believe the available chat
context was much smaller than it really was. That affected both the UI
displayed token window and the internal history-management behavior used
by Copilot Chat.

The most important effect is that VS Code can now use more of the actual
available context window before summarizing or compacting older turns.

## Overrides

If automatic detection is not appropriate for a given provider, users can
override the advertised values with:

- `llama-vscode.lm_max_input_tokens`
- `llama-vscode.lm_max_output_tokens`

Set either value to `0` to keep auto-detection enabled, or set a
positive value to force an explicit limit.

## Scope

This PR is focused on token-limit detection and reporting for the VS Code
language model provider path.

## Validation

- Verified the branch compiles cleanly in the local build environment
- Added and updated token-limit resolution tests
- Confirmed the provider now reports resolved token limits to VS Code
  instead of relying on the previous fallback behavior