### PR TITLE
fix: can't view all elements vertically on scaled vscode instance

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -39,7 +39,8 @@ body {
   flex-direction: column;
   background-color: var(--vscode-editor-background);
   color: var(--vscode-editor-foreground);
-  overflow: hidden; /* Prevent any overflow issues */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Modern Header */


### PR DESCRIPTION
Without this fix it's impossible to scroll or select elements on the y axis. You can't scroll/select or save any of your changes on vscode instances that are _slightly_ zoomed in. 

Before:
<img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/feb84891-1ab5-4c50-a96d-8978121d1afa" />

After:
<img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/65b15285-ab9b-49a8-8297-fbe6be3ceb57" />
