### PR TITLE
Use shell script for llama.cpp installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,40 +75,40 @@ Here are recommended settings, depending on the amount of VRAM that you have:
 - More than 64GB VRAM:
 
   ```bash
-  llama-server --fim-qwen-30b-default
+  llama serve --fim-qwen-30b-default
   ```
 
 - More than 16GB VRAM:
 
   ```bash
-  llama-server --fim-qwen-7b-default
+  llama serve --fim-qwen-7b-default
   ```
 
 - Less than 16GB VRAM:
 
   ```bash
-  llama-server --fim-qwen-3b-default
+  llama serve --fim-qwen-3b-default
   ```
 
 - Less than 8GB VRAM:
 
   ```bash
-  llama-server --fim-qwen-1.5b-default
+  llama serve --fim-qwen-1.5b-default
   ```
 
 <details>
   <summary>CPU-only configs</summary>
 
-These are `llama-server` settings for CPU-only hardware. Note that the quality will be significantly lower:
+These are `llama serve` settings for CPU-only hardware. Note that the quality will be significantly lower:
 
 ```bash
-llama-server \
+llama serve \
     -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF \
     --port 8012 -ub 512 -b 512 --ctx-size 0 --cache-reuse 256
 ```
 
 ```bash
-llama-server \
+llama serve \
     -hf ggml-org/Qwen2.5-Coder-0.5B-Q8_0-GGUF \
     --port 8012 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,29 +531,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -583,9 +560,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -604,9 +581,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
-      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -693,6 +670,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -721,32 +713,10 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1177,9 +1147,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1225,9 +1195,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1316,9 +1286,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1368,6 +1338,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1411,9 +1394,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -1431,10 +1414,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.1"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1503,9 +1487,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1905,9 +1889,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.72",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
-      "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1919,14 +1903,14 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+      "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -1964,9 +1948,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2121,9 +2105,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2394,24 +2378,40 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2877,9 +2877,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2887,13 +2897,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -2936,13 +2939,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -3827,9 +3834,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3873,19 +3880,80 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/minipass": {
@@ -3899,9 +3967,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4108,11 +4176,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4415,9 +4486,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4578,9 +4649,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4785,9 +4856,9 @@
       "license": "MIT"
     },
     "node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4884,13 +4955,15 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
-      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       },
       "funding": {
@@ -5093,24 +5166,28 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -5119,41 +5196,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
       }
     },
     "node_modules/test-exclude": {
@@ -5172,9 +5214,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5205,9 +5247,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5352,9 +5394,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -5373,7 +5415,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -5433,13 +5475,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -5462,37 +5503,34 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+      "version": "5.108.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.1.tgz",
+      "integrity": "sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.22.2",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -5584,9 +5622,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5615,6 +5653,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -802,28 +802,28 @@
           "default": [
             {
               "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (CPU Only)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
@@ -868,39 +868,39 @@
           "default": [
             {
               "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF (> 32GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (CPU Only)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "gemini qat tools",
-              "localStartCommand": "llama-server -m c:\\ai\\gemma-3-4B-it-QAT-Q4_0.gguf --port 8011",
+              "localStartCommand": "llama serve -m c:\\ai\\gemma-3-4B-it-QAT-Q4_0.gguf --port 8011",
               "endpoint": "http://localhost:8011",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "OpenAI gpt-oss 20B",
-              "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8011",
               "endpoint": "http://localhost:8011",
               "aiModel": "",
               "isKeyRequired": false
@@ -945,7 +945,7 @@
           "default": [
             {
               "name": "Nomic-Embed-Text-V2-GGUF",
-              "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+              "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
               "endpoint": "http://127.0.0.1:8010"
             }
           ],
@@ -988,7 +988,7 @@
           "default": [
             {
               "name": "OpenAI gpt-oss 20B (LOCAL) (> 19GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+              "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
@@ -1282,24 +1282,24 @@
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1310,24 +1310,24 @@
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1338,24 +1338,24 @@
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1366,7 +1366,7 @@
               "description": "For laptops only with CPU, lightweight model for completion ",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (CPU Only)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1398,7 +1398,7 @@
               "description": "Only for code completions model Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1430,7 +1430,7 @@
               "description": "Only for completions, model Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM | HD: 3,2 GB)",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1462,7 +1462,7 @@
               "description": "Only for code completions, model Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM | HD: 8.1 GB)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -1498,7 +1498,7 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (CPU Only)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
@@ -1519,12 +1519,12 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1541,7 +1541,7 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
@@ -1562,12 +1562,12 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1584,12 +1584,12 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1604,19 +1604,19 @@
               "description": "The minimal configuration for completions (local), chat (local) and agent (remote - OpenRouter), requires OpenRouter API key for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1631,19 +1631,19 @@
               "description": "Agent qwen 3 from OpenRouter, completions & chat - medium size models, embeddings (<= 32GB VRAM))",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1658,19 +1658,19 @@
               "description": "Agent - qwen 3 from OpenRouter (API key required), completions, chat (>32 GB VRAM) ",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -1689,12 +1689,12 @@
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {

--- a/resources/help.md
+++ b/resources/help.md
@@ -927,7 +927,10 @@ Show llama-vscode menu (Ctrl+Shift+M) and select "Install/upgrade llama.cpp" (if
 
 The instructions below are left for a reference, but now it is possible to do it easier - add a model from the menu and select it.
 
-#### Prerequisites - [Homebrew](https://brew.sh/)
+#### With shellscript:  
+Go to https://llama.app/, copy the install command and run it in a shell.
+
+#### With brew. Prerequisites - [Homebrew](https://brew.sh/)
 
 ### Code completion server
 *Used for*  
@@ -1024,11 +1027,11 @@ Download the release files for Windows for llama.cpp from [releases](https://git
 #### Run llama.cpp server  
 No GPUs   
 ```bash
-`llama serve --fim-qwen-1.5b-default --port 8012`  
+`llama serve.exe --fim-qwen-1.5b-default --port 8012`  
 ```
 With GPUs     
 ```bash
-`llama serve --fim-qwen-1.5b-default --port 8012 -ngl 99`  
+`llama serve.exe --fim-qwen-1.5b-default --port 8012 -ngl 99`  
 ```  
 If you've installed llama.cpp with winget you could skip the .exe suffix and use just llama serve in the commands.  
 
@@ -1052,21 +1055,21 @@ Same like code completion server, but use chat model and a little bit different 
 
 CPU-only:  
 ```bash
-`llama serve -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011`  
+`llama serve.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011`  
 ```
 
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM  
 ```bash
-`llama serve -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
+`llama serve.exe -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama serve -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
+`llama serve.exe -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama serve -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99` 
+`llama serve.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99` 
 ```
 
 
@@ -1080,7 +1083,7 @@ With Nvidia GPUs and installed cuda drivers
 *Instructions*  
 Same like code completion server, but use embeddings model and a little bit different parameters.   
 ```bash
-`llama serve -hf nomic-embed-text-v2-moe-q8_0.gguf --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
+`llama serve.exe -hf nomic-embed-text-v2-moe-q8_0.gguf --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
 ```
 ## Skills
 

--- a/resources/help.md
+++ b/resources/help.md
@@ -96,7 +96,7 @@ llama-vscode provides to the users the posibility to partially create their own 
 Configure the description of the tool and the returned result, enable the tool and ask the agent questions related to the tool.
 
 Settings:
-- Tool_custom_tool_description: Description of the tool. This description will be used by the AI to decide if this tool should be used. Example: "Use this tool for information about llama.cpp and llama-server - how to build it, how to use it, options, etc."
+- Tool_custom_tool_description: Description of the tool. This description will be used by the AI to decide if this tool should be used. Example: "Use this tool for information about llama.cpp and llama serve - how to build it, how to use it, options, etc."
 - Custom_tool_source: What should be returned by the tool. Could be file or a web page. Eample:  https://blog.steelph0enix.dev/posts/llama-cpp-guide/ ​The tool returns the content of the file or the web page.
 
 
@@ -359,7 +359,7 @@ llama-vscode is an extension for code completion, chat with ai and agentic codin
 
 ### How to use it 
 1. Install llama.cpp  
-- Show llama-vscode menu by clicking "llama-vscode" in the status bar or by Ctrl+Shift+M, and select 'Install/upgrade llama.cpp' (sometimes restart is needed to adjust the paths to llama-server)
+- Show llama-vscode menu by clicking "llama-vscode" in the status bar or by Ctrl+Shift+M, and select 'Install/upgrade llama.cpp' (sometimes restart is needed to adjust the paths to llama serve)
 2. Select env (group of models) for your needs from llama-vscode menu.  
 - This will download (only the first time) the models and run llama.cpp servers locally (or use external servers endpoints, depends on env)
 3. Start using llama-vscode  
@@ -420,7 +420,7 @@ https://github.com/user-attachments/assets/dd9da21a-6f57-477d-a55c-e4ff60b1ecb8
 ## Use as local AI runner (as LM Studio, Ollama, etc.) 
 
 ### Overview
-llama-vscode could be used as a local AI runner (as LM Studio, Ollama, etc.) . Models are searched in Huggingface. After a model is selected, llama-vscode automatically downloads it and starts a llama-server with it. With this the user could start chatting with an AI.
+llama-vscode could be used as a local AI runner (as LM Studio, Ollama, etc.) . Models are searched in Huggingface. After a model is selected, llama-vscode automatically downloads it and starts a llama serve with it. With this the user could start chatting with an AI.
 
 ### How to use it
 1. From llama-vscode menu select "Use as local AI runner" - llama view will be opened with buttons "llama.cpp", "Add", "Select", "Chat".
@@ -485,7 +485,7 @@ An agent could be imported from a .json file - select a file to import it.
 ### Overview
 Chat models configurations are stored and could be reused. For simplicity the term "chat models" will be used as a synonim for chat models configurations.
 Chat models could be for local models (run by llama-vscode) and for externally run servers.
-They have properties: name, local start command (llama-server command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
+They have properties: name, local start command (llama serve command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
  
 
 Chat models configurations could be added/deleted/viewed/selected/deselected/added from huggingface/exported/imported
@@ -558,7 +558,7 @@ A chat could be imported from a .json file - select a file to import it.
 ### Overview
 Completion models configurations are stored and could be reused. For simplicity the term "completion models" will be used as a synonim for Completion models configurations.
 Completion models could be for local models (run by llama-vscode) and for externally run servers.
-They have properties: name, local start command (llama-server command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
+They have properties: name, local start command (llama serve command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
  
 
 Completion models configurations could be added/deleted/viewed/selected/deselected/added from huggingface/exported/imported
@@ -606,7 +606,7 @@ A model could be imported from a .json file - select a file to import it.## Mana
 ### Overview
 Embeddings models configurations are stored and could be reused. For simplicity the term "embeddings models" will be used as a synonim for embeddings models configurations.
 Embeddings models could be for local models (run by llama-vscode) and for externally run servers.
-They have properties: name, local start command (llama-server command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
+They have properties: name, local start command (llama serve command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
  
 
 Embeddings models configurations could be added/deleted/viewed/selected/deselected/added from huggingface/exported/imported
@@ -702,7 +702,7 @@ https://github.com/user-attachments/assets/3b8dffcc-bcdc-4981-b181-ffc52fe43075
 ### Overview
 Tools models configurations are stored and could be reused. For simplicity the term "tools models" will be used as a synonim for tools models configurations.
 Tools models could be for local models (run by llama-vscode) and for externally run servers.
-They have properties: name, local start command (llama-server command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
+They have properties: name, local start command (llama serve command to start a server with this model locally), ai model (as required by the provider), endpoint, is key required  
  
 
 Tools models configurations could be added/deleted/viewed/selected/deselected/added from huggingface/exported/imported
@@ -857,21 +857,21 @@ The configurations below are left for a reference, but now it is possible to do 
 CPU only
 
 ```bash
-llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF --port 8012 -ub 512 -b 512 --ctx-size 0 --cache-reuse 256
+llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF --port 8012 -ub 512 -b 512 --ctx-size 0 --cache-reuse 256
 ```
 
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM 
 ```bash 
-`llama-server --fim-qwen-7b-default -ngl 99`  
+`llama serve --fim-qwen-7b-default -ngl 99`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama-server --fim-qwen-3b-default -ngl 99`  
+`llama serve --fim-qwen-3b-default -ngl 99`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama-server --fim-qwen-1.5b-default -ngl 99`  
+`llama serve --fim-qwen-1.5b-default -ngl 99`  
 ```
 If the file is not available (first time) it will be downloaded (this could take some time) and after that llama.cpp server will be started.  
   
@@ -891,21 +891,21 @@ Same like code completion server, but use chat model and a little bit different 
 
 CPU-only:  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 
 
@@ -919,7 +919,7 @@ With Nvidia GPUs and installed cuda drivers
 *Instructions*  
 Same like code completion server, but use embeddings model and a little bit different parameters. 
 ```bash  
-`llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
+`llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
 ```
 ### Setup llama.cpp servers for Mac  
 
@@ -946,11 +946,11 @@ The instructions below are left for a reference, but now it is possible to do it
 2. Download the LLM model and run llama.cpp server (combined in one command)  
 - If you have more than 16GB VRAM:  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF:Q8_0 --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF:Q8_0 --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256`  
 ```
 - If you have less than 16GB VRAM:  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF:Q8_0 --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF:Q8_0 --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256`  
 ```
 If the file is not available (first time) it will be downloaded (this could take some time) and after that llama.cpp server will be started. 
 
@@ -969,21 +969,21 @@ Same like code completion server, but use chat model and a little bit different 
 
 CPU-only:
 ```bash  
-`llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
+`llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF --port 8011 -np 2`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2` 
+`llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF --port 8011 -np 2` 
 ```
 
 ### Embeddings server  
@@ -996,7 +996,7 @@ With Nvidia GPUs and installed cuda drivers
 *Instructions*  
 Same like code completion server, but use embeddings model and a little bit different parameters.   
 ```bash
-`llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
+`llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
 ```
 
 ### Setup llama.cpp servers for Windows  
@@ -1024,13 +1024,13 @@ Download the release files for Windows for llama.cpp from [releases](https://git
 #### Run llama.cpp server  
 No GPUs   
 ```bash
-`llama-server.exe --fim-qwen-1.5b-default --port 8012`  
+`llama serve --fim-qwen-1.5b-default --port 8012`  
 ```
 With GPUs     
 ```bash
-`llama-server.exe --fim-qwen-1.5b-default --port 8012 -ngl 99`  
+`llama serve --fim-qwen-1.5b-default --port 8012 -ngl 99`  
 ```  
-If you've installed llama.cpp with winget you could skip the .exe suffix and use just llama-server in the commands.  
+If you've installed llama.cpp with winget you could skip the .exe suffix and use just llama serve in the commands.  
 
 Now you could start using llama-vscode extension for code completion.  
 
@@ -1052,21 +1052,21 @@ Same like code completion server, but use chat model and a little bit different 
 
 CPU-only:  
 ```bash
-`llama-server.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011`  
+`llama serve -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011`  
 ```
 
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM  
 ```bash
-`llama-server.exe -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
+`llama serve -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama-server.exe -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
+`llama serve -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama-server.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99` 
+`llama serve -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011 -np 2 -ngl 99` 
 ```
 
 
@@ -1080,7 +1080,7 @@ With Nvidia GPUs and installed cuda drivers
 *Instructions*  
 Same like code completion server, but use embeddings model and a little bit different parameters.   
 ```bash
-`llama-server.exe -hf nomic-embed-text-v2-moe-q8_0.gguf --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
+`llama serve -hf nomic-embed-text-v2-moe-q8_0.gguf --port 8010 -ub 2048 -b 2048 --ctx-size 2048 --embeddings`  
 ```
 ## Skills
 

--- a/src/architect.ts
+++ b/src/architect.ts
@@ -511,7 +511,7 @@ export class Architect {
 
     private async installUpgradeLlamaCpp(isFirstStart: any) {
         if (!this.app.configuration.ask_install_llamacpp) return;
-        let { stdout, stderr }  = await this.app.llamaServer.executeCommandWithTerminalFeedback("llama-server --version");
+        let { stdout, stderr }  = await this.app.llamaServer.executeCommandWithTerminalFeedback("llama serve --version");
         stderr = stderr.toLowerCase();
         if (stderr.includes("command not found") || stderr.includes("command failed") || stderr.includes("is not recognized")) {
             let questionInstall = "llama.cpp will be installed as it is requred by llama-vscode extension.";

--- a/src/chat-with-ai.ts
+++ b/src/chat-with-ai.ts
@@ -63,9 +63,9 @@ export class ChatWithAi {
         }
         if (!targetUrl) {
             await this.app.dialogs.suggestModelSelection(
-                "Select a chat or tools model run by llama-server or an env with chat or tools model run on llama-server to chat with AI.",
+                "Select a chat or tools model run by llama serve or an env with chat or tools model run on llama serve to chat with AI.",
                 "After the chat/tools model is loaded, try again opening Chat with AI.",
-                "No endpoint for the chat or tools model. Select a chat or tools model run on llama-server or an env with chat or tools model or enter the endpoint of a running llama.cpp server with chat model in setting endpoint_chat. ",
+                "No endpoint for the chat or tools model. Select a chat or tools model run on llama serve or an env with chat or tools model or enter the endpoint of a running llama.cpp server with chat model in setting endpoint_chat. ",
                 this.app
             );
             return

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,17 +65,17 @@ export const MODEL_TYPE_CONFIG = {
 } as const;
 
 export const LOCAL_MODEL_TEMPLATES = {
-  [ModelType.Completion]: 'llama-server -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Chat]: 'llama-server -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Embeddings]: 'llama-server -hf <model name from hugging face, i.e: ggml-org/Nomic-Embed-Text-V2-GGUF> -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Tools]: 'llama-server -hf <model name from hugging face, i.e: unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q8_0> --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER'
+  [ModelType.Completion]: 'llama serve -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Chat]: 'llama serve -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Embeddings]: 'llama serve -hf <model name from hugging face, i.e: ggml-org/Nomic-Embed-Text-V2-GGUF> -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Tools]: 'llama serve -hf <model name from hugging face, i.e: unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q8_0> --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER'
 } as const;
 
 export const HF_MODEL_TEMPLATES = {
-  [ModelType.Completion]: 'llama-server -hf MODEL_PLACEHOLDER -ngl 99 -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Chat]: 'llama-server -hf MODEL_PLACEHOLDER -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Embeddings]: 'llama-server -hf MODEL_PLACEHOLDER -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
-  [ModelType.Tools]: 'llama-server -hf MODEL_PLACEHOLDER --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER'
+  [ModelType.Completion]: 'llama serve -hf MODEL_PLACEHOLDER -ngl 99 -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Chat]: 'llama serve -hf MODEL_PLACEHOLDER -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Embeddings]: 'llama serve -hf MODEL_PLACEHOLDER -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER',
+  [ModelType.Tools]: 'llama serve -hf MODEL_PLACEHOLDER --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port PORT_PLACEHOLDER --host HOST_PLACEHOLDER'
 } as const;
 
 export const SETTING_TO_MODEL_TYPE: Record<string, ModelType> = {

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -80,6 +80,21 @@ export class Dialogs {
         return result;
     }
 
+    showInstallLlamacppDialog = async (message: string, label1: string, label2: string): Promise<boolean> => {            
+        const dialogDetails: DialogDetails = {
+            message: UI_TEXT_KEYS.extensionName,
+            details: message,
+            title: "Confirmation",
+            buttons: [
+                { label: label1, response: "true", default: true },
+                { label: label2, response: "false" },
+            ]
+        }
+
+        const [result] = await this.showCustomDialog(dialogDetails) as [boolean]
+        return result;
+    }
+
     showYesYesdontaskNoDialog = async (message: string): Promise<[boolean, boolean]> => {
         if (message.length < this.app.configuration.popup_max_chars) {
             const choice = await vscode.window.showInformationMessage(

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -4,28 +4,28 @@ export const PREDEFINED_LISTS = new Map<string, any>([
     [PREDEFINED_LISTS_KEYS.COMPLETIONS, [
             {
               "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-              "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+              "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (CPU Only)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
               "endpoint": "http://localhost:8012",
               "aiModel": "",
               "isKeyRequired": false
@@ -34,39 +34,39 @@ export const PREDEFINED_LISTS = new Map<string, any>([
 [PREDEFINED_LISTS_KEYS.CHATS, [
             {
               "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF (> 32GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-14B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (CPU Only)",
-              "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
               "endpoint": "http://127.0.0.1:8011"
             },
             {
               "name": "gemini qat tools",
-              "localStartCommand": "llama-server -m c:\\ai\\gemma-3-4B-it-QAT-Q4_0.gguf --port 8011",
+              "localStartCommand": "llama serve -m c:\\ai\\gemma-3-4B-it-QAT-Q4_0.gguf --port 8011",
               "endpoint": "http://localhost:8011",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "OpenAI gpt-oss 20B",
-              "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8011",
+              "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8011",
               "endpoint": "http://localhost:8011",
               "aiModel": "",
               "isKeyRequired": false
@@ -75,43 +75,50 @@ export const PREDEFINED_LISTS = new Map<string, any>([
 [PREDEFINED_LISTS_KEYS.EMBEDDINGS,  [
             {
               "name": "Nomic-Embed-Text-V2-GGUF",
-              "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+              "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
               "endpoint": "http://127.0.0.1:8010"
             }
           ]],
 [PREDEFINED_LISTS_KEYS.TOOLS,
     [
             {
+              "name": "Qwen3.6-27B-GGUF:Q8_0 MTP (LOCAL) (VRAM>20)",
+              "localStartCommand": 'llama serve -hf ggml-org/Qwen3.6-27B-GGUF:Q8_0 --spec-draft-hf ggml-org/Qwen3.5-0.8B-GGUF:Q8_0 --ctx-size 262144 --batch-size 2048 --ubatch-size 2048 --chat-template-kwargs {"preserve_thinking": true}',
+              "endpoint": "http://localhost:8009",
+              "aiModel": "",
+              "isKeyRequired": false
+            },
+            {
               "name": "Qwen3.5-2B-GGUF:Q8_0 (LOCAL) (CPU)",
-              "localStartCommand": "llama-server -hf unsloth/Qwen3.5-2B-GGUF:Q8_0 --jinja  -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
+              "localStartCommand": "llama serve -hf unsloth/Qwen3.5-2B-GGUF:Q8_0 --jinja  -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen3.5-2B-GGUF:Q8_0 (LOCAL) (VRAM>3GB)",
-              "localStartCommand": "llama-server -hf unsloth/Qwen3.5-2B-GGUF:Q8_0 --jinja -ngl 99  -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
+              "localStartCommand": "llama serve -hf unsloth/Qwen3.5-2B-GGUF:Q8_0 --jinja -ngl 99  -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen3.5-4B-GGUF:Q8_0 (LOCAL) (VRAM>6GB)",
-              "localStartCommand": "llama-server -hf unsloth/Qwen3.5-4B-GGUF:Q8_0 --jinja -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
+              "localStartCommand": "llama serve -hf unsloth/Qwen3.5-4B-GGUF:Q8_0 --jinja -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "Qwen3.5-9B-GGUF:Q8_0 (LOCAL) (VRAM>12GB)",
-              "localStartCommand": "llama-server -hf unsloth/Qwen3.5-9B-GGUF:Q8_0 --jinja -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
+              "localStartCommand": "llama serve -hf unsloth/Qwen3.5-9B-GGUF:Q8_0 --jinja -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port 8009 --host 127.0.0.1",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
             },
             {
               "name": "OpenAI gpt-oss 20B (LOCAL) (> 19GB VRAM)",
-              "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+              "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
               "endpoint": "http://localhost:8009",
               "aiModel": "",
               "isKeyRequired": false
@@ -198,24 +205,24 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -226,24 +233,24 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -254,24 +261,24 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Everything local, gpt-oss 20B for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
                 "name": "OpenAI gpt-oss 20B",
-                "localStartCommand": "llama-server -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
+                "localStartCommand": "llama serve -hf ggml-org/gpt-oss-20b-GGUF -c 0 --jinja --reasoning-format none -np 2 --port 8009",
                 "endpoint": "http://localhost:8009",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -282,7 +289,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "For laptops only with CPU, lightweight model for completion ",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (CPU Only)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -314,7 +321,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Only for code completions model Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -346,7 +353,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Only for completions, model Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM | HD: 3,2 GB)",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -378,7 +385,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Only for code completions, model Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM | HD: 8.1 GB)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
@@ -414,7 +421,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (CPU Only)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ub 1024 -b 1024 -dt 0.1 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
@@ -435,12 +442,12 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -457,7 +464,7 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
@@ -478,12 +485,12 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -500,12 +507,12 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -520,19 +527,19 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "The minimal configuration for completions (local), chat (local) and agent (remote - OpenRouter), requires OpenRouter API key for agent",
               "completion": {
                 "name": "Qwen2.5-Coder-1.5B-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-1.5b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-1.5b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -547,19 +554,19 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Agent qwen 3 from OpenRouter, completions & chat - medium size models, embeddings (<= 32GB VRAM))",
               "completion": {
                 "name": "Qwen2.5-Coder-3B-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-3b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-3b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF (<= 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-3B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -574,19 +581,19 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "description": "Agent - qwen 3 from OpenRouter (API key required), completions, chat (>32 GB VRAM) ",
               "completion": {
                 "name": "Qwen2.5-Coder-7B-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server --fim-qwen-7b-default -ngl 99 --port 8012",
+                "localStartCommand": "llama serve --fim-qwen-7b-default -ngl 99 --port 8012",
                 "endpoint": "http://localhost:8012",
                 "aiModel": "",
                 "isKeyRequired": false
               },
               "chat": {
                 "name": "Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF (> 16GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {
@@ -605,12 +612,12 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               },
               "chat": {
                 "name": "Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF (<= 8GB VRAM)",
-                "localStartCommand": "llama-server -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
+                "localStartCommand": "llama serve -hf ggml-org/Qwen2.5-Coder-1.5B-Instruct-Q8_0-GGUF -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port 8011",
                 "endpoint": "http://127.0.0.1:8011"
               },
               "embeddings": {
                 "name": "Nomic-Embed-Text-V2-GGUF",
-                "localStartCommand": "llama-server -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
+                "localStartCommand": "llama serve -hf ggml-org/Nomic-Embed-Text-V2-GGUF -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port 8010",
                 "endpoint": "http://127.0.0.1:8010"
               },
               "tools": {

--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -1134,6 +1134,7 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             return;
         }
         try {
+            launchCmd = this.useNewLaunchCommand(launchCmd);
             this.vsCodeFimTerminal = vscode.window.createTerminal({
                 name: 'llama.cpp Completion Terminal'
             });
@@ -1152,6 +1153,7 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             return;
         }
         try {
+            launchCmd = this.useNewLaunchCommand(launchCmd);
             this.vsCodeChatTerminal = vscode.window.createTerminal({
                 name: 'llama.cpp Chat Terminal'
             });
@@ -1170,6 +1172,7 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             return;
         }
         try {
+            launchCmd = this.useNewLaunchCommand(launchCmd);
             this.vsCodeEmbeddingsTerminal = vscode.window.createTerminal({
                 name: 'llama.cpp Embeddings Terminal'
             });
@@ -1188,6 +1191,7 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
             return;
         }
         try {
+            launchCmd = this.useNewLaunchCommand(launchCmd);
             this.vsCodeToolsTerminal = vscode.window.createTerminal({
                 name: 'llama.cpp Tools Terminal'
             });
@@ -1366,6 +1370,16 @@ private createGetSummaryRequestPayload(messages: ChatMessage[], model: string) {
         }
     }
 
+
+    private useNewLaunchCommand(launchCmd: string) {
+        const oldCommand = "llama-server ";
+        const newCommand = "llama serve ";
+        if (launchCmd.startsWith("llama-server ")) {
+            launchCmd = launchCmd;
+            launchCmd = newCommand + launchCmd.substring(newCommand.length);
+        }
+        return launchCmd;
+    }
 
     private getChatModelProperties() {
         let selectedModel: LlmModel = this.app.getChatModel();

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -386,11 +386,11 @@ export class Menu {
                     return;
                 }
             } else if (process.platform === 'win32') {
-                const useShellScript = await this.app.dialogs.showInstallLlamacppDialog("How to install llama.cpp?","shell script", "winget")
-                    if (useShellScript) {
-                        terminalCommand = "irm https://llama.app/install.ps1 | iex";
-                    } else {
+                const useWinget = await this.app.dialogs.showInstallLlamacppDialog("How to install llama.cpp?","winget", "shell script")
+                    if (useWinget) {
                         terminalCommand = `winget install --id ggml.llamacpp -e${wingetArch ? ` -a ${wingetArch}` : ""}`;
+                    } else {
+                        terminalCommand = "irm https://llama.app/install.ps1 | iex";
                     }
             }
             if (terminalCommand) {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -349,7 +349,7 @@ export class Menu {
                 this.app.llamaWebviewProvider.showAgentView();
                 break;
             case this.app.configuration.getUiText(UI_TEXT_KEYS.howToDeleteModels):
-                this.app.dialogs.showOkDialog("The automatically downloaded models (llama-server started with -hf option) are stored as follows: \nIn Windows in folder C:\\Users\\<user_name>\\AppData\\Local\\llama.cpp. \nIn Mac or Linux the folder could be /users/<user_name>/Library/Caches/llama.cpp. \nYou could delete them from the folder.");
+                this.app.dialogs.showOkDialog("The automatically downloaded models (llama serve started with -hf option) are stored as follows: \nIn Windows in folder C:\\Users\\YourUsername\\.cache\\huggingface\\hub. \nIn Mac and Linux ~/.cache/huggingface/hub. \nYou could delete them from the folder.");
                 break;
             case "$(book) " + this.app.configuration.getUiText(UI_TEXT_KEYS.viewDocumentation):
                 await vscode.env.openExternal(vscode.Uri.parse('https://github.com/ggml-org/llama.vscode/wiki'));
@@ -363,7 +363,7 @@ export class Menu {
 
     public async installLlamacpp() {
         if (process.platform != 'darwin' && process.platform != 'win32' && process.platform != 'linux') {
-            vscode.window.showInformationMessage("Automatic install/upgrade is supported only for Mac and Windows and Linux (with brew package manager) for now. Download llama.cpp package manually and add the folder to the path. Visit github.com/ggml-org/llama.vscode/wiki for details.");
+            vscode.window.showInformationMessage("Automatic install/upgrade is supported only for Mac and Windows and Linux for now. Download llama.cpp package manually and add the folder to the path. Visit github.com/ggml-org/llama.vscode/wiki for details.");
         } else {
             await this.app.llamaServer.killCommandCmd();
             const windowsArch = os.machine().toLowerCase();
@@ -371,17 +371,27 @@ export class Menu {
             let terminalCommand = '';
             if (process.platform === 'darwin' || process.platform === 'linux') {
                 try {
-                    const { stdout, stderr } = await this.app.llamaServer.executeCommandWithTerminalFeedback('command -v brew');
-                    if (!stdout || !stdout.trim()) {
-                        throw new Error('brew not found');
+                    const useShellScript = await this.app.dialogs.showInstallLlamacppDialog("How to install llama.cpp?","shell script", "brew")
+                    if (useShellScript) {
+                        terminalCommand = "curl -LsSf https://llama.app/install.sh | sh";
+                    } else {
+                        const { stdout, stderr } = await this.app.llamaServer.executeCommandWithTerminalFeedback('command -v brew');
+                        if (!stdout || !stdout.trim()) {
+                            throw new Error('brew not found');
+                        }
+                        terminalCommand = "brew install -y llama.cpp";
                     }
-                    terminalCommand = "brew install -y llama.cpp";
                 } catch (error) {
                     vscode.window.showErrorMessage("Homebrew is not installed (llama.cpp is installed with brew). Please install Homebrew from https://brew.sh before proceeding.");
                     return;
                 }
             } else if (process.platform === 'win32') {
-                terminalCommand = `winget install --id ggml.llamacpp -e${wingetArch ? ` -a ${wingetArch}` : ""}`;
+                const useShellScript = await this.app.dialogs.showInstallLlamacppDialog("How to install llama.cpp?","shell script", "winget")
+                    if (useShellScript) {
+                        terminalCommand = "irm https://llama.app/install.ps1 | iex";
+                    } else {
+                        terminalCommand = `winget install --id ggml.llamacpp -e${wingetArch ? ` -a ${wingetArch}` : ""}`;
+                    }
             }
             if (terminalCommand) {
                 await this.app.llamaServer.executeCommandWithTerminalFeedback(terminalCommand);
@@ -394,7 +404,7 @@ export class Menu {
             "\n\nTL;DR,: install llama.cpp, select env, start using" +
             "\n\nllama-vscode is an extension for code completion, chat with ai and agentic coding, focused on local model usage with llama.cpp." +
             "\n\n1. Install llama.cpp " +
-            "\n  - Show the extension menu by clicking llama-vscode in the status bar or by Ctrl+Shift+M and select 'Install/upgrade llama.cpp' (sometimes restart is needed to adjust the paths to llama-server)" +
+            "\n  - Show the extension menu by clicking llama-vscode in the status bar or by Ctrl+Shift+M and select 'Install/upgrade llama.cpp' (sometimes restart is needed to adjust the paths to llama serve)" +
             "\n\n2. Select env (group of models) for your needs from llama-vscode menu." +
             "\n  - This will download (only the first time) the models and run llama.cpp servers locally (or use external servers endpoints, depends on env)" +
             "\n\n3. Start using llama-vscode" +

--- a/src/services/external-model-strategy.ts
+++ b/src/services/external-model-strategy.ts
@@ -43,7 +43,7 @@ export class ExternalModelStrategy implements IAddStrategy {
         endpoint = this.sanitizeInput(endpoint);
         let aiModel = await vscode.window.showInputBox({
             placeHolder: 'Model name, exactly as expected by the provider, i.e. kimi-latest ',
-            prompt: 'Enter model name as expected by the provider (leave empty if llama-server is used)',
+            prompt: 'Enter model name as expected by the provider (leave empty if llama serve is used)',
             value: ''
         });
         aiModel = this.sanitizeInput(aiModel || '');

--- a/src/services/local-model-strategy.ts
+++ b/src/services/local-model-strategy.ts
@@ -14,10 +14,10 @@ export class LocalModelStrategy implements IAddStrategy {
     async add(details: ModelTypeDetails): Promise<void> {
         const hostEndpoint = "http://" + details.newModelHost;
         const modelListToLocalCommand = new Map([
-            ["completion_models_list", "llama-server -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 --port " + details.newModelPort + " --host " + details.newModelHost],
-            ["chat_models_list", 'llama-server -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port ' + details.newModelPort + " --host " + details.newModelHost],
-            ["embeddings_models_list", "llama-server -hf <model name from hugging face, i.e: ggml-org/Nomic-Embed-Text-V2-GGUF> -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port " + details.newModelPort + " --host " + details.newModelHost],
-            ["tools_models_list", "llama-server -hf <model name from hugging face, i.e: unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q8_0> --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port " + details.newModelPort + " --host " + details.newModelHost]
+            ["completion_models_list", "llama serve -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 --port " + details.newModelPort + " --host " + details.newModelHost],
+            ["chat_models_list", 'llama serve -hf <model name from hugging face, i.e: ggml-org/Qwen2.5-Coder-7B-Instruct-Q8_0-GGUF> -ngl 99 -ub 1024 -b 1024 --ctx-size 0 --cache-reuse 256 -np 2 --port ' + details.newModelPort + " --host " + details.newModelHost],
+            ["embeddings_models_list", "llama serve -hf <model name from hugging face, i.e: ggml-org/Nomic-Embed-Text-V2-GGUF> -ngl 99 -ub 2048 -b 2048 --ctx-size 2048 --embeddings --port " + details.newModelPort + " --host " + details.newModelHost],
+            ["tools_models_list", "llama serve -hf <model name from hugging face, i.e: unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q8_0> --jinja  -ngl 99 -c 0 -ub 1024 -b 1024 --cache-reuse 256 --port " + details.newModelPort + " --host " + details.newModelHost]
         ]);
 
         let name = await Utils.getValidatedInput(
@@ -40,7 +40,7 @@ export class LocalModelStrategy implements IAddStrategy {
             (input) => input.trim() !== '',
             5,
             {
-                placeHolder: 'A command to start the model locally, i.e. llama-server -m model_name.gguf --port '+ details.newModelPort + '. (required for local model)',
+                placeHolder: 'A command to start the model locally, i.e. llama serve -m model_name.gguf --port '+ details.newModelPort + '. (required for local model)',
                 value: modelListToLocalCommand.get(details.modelsListSettingName) || ''
             }
         );

--- a/src/services/model-service.ts
+++ b/src/services/model-service.ts
@@ -339,7 +339,7 @@ export class ModelService {
                 modelsItems.push({
                     label: i + ". " + prefix + model.name,
                     description: model.localStartCommand,
-                    detail: "Selects the model" + (model.localStartCommand ? ", downloads the model (if not yet done) and starts a llama-server with it." : "")
+                    detail: "Selects the model" + (model.localStartCommand ? ", downloads the model (if not yet done) and starts a llama serve with it." : "")
                 });
             } else {
                 modelsItems.push({


### PR DESCRIPTION
- Option for using standard shell script for llama.cpp installation (brew and winget also possible)
- Use "llama server" instead of llama-server to start a local server
- Added one predefined local model with Multi Token Prediction: Qwen3.6-27B-GGUF:Q8_0 MTP (LOCAL) (VRAM>20)