### PR TITLE
Fix: add role: 'assistant' to fallback error message in createErrorResponse

### DIFF
--- a/src/llama-server.ts
+++ b/src/llama-server.ts
@@ -27,7 +27,7 @@ const STATUS_OK = 200;
 
 export interface LlamaToolsResponse {
     choices: [{
-        message:{content?: string | null, tool_calls?:[{id:string, function: {name:string, arguments: string}}]},
+        message:{role?: string, content?: string | null, tool_calls?:[{id:string, function: {name:string, arguments: string}}]},
         finish_reason?: string,
         error?: LlamaApiError,
     }];
@@ -725,7 +725,7 @@ export class LlamaServer {
     private createErrorResponse(error: LlamaApiError): LlamaToolsResponse {
         return {
             choices: [{
-                message: { content: error.message },
+                message: { role: 'assistant', content: error.message },
                 finish_reason: 'error',
                 error,
             }],


### PR DESCRIPTION
## Description

Fixes #202 

## Problem

When a request to the model fails (bad endpoint, network error, timeout, etc.), the fallback error message that gets built has no role field. This malformed message is pushed into the conversation history (this.messages in llama-agent.ts) as if it were a normal assistant turn. Since every subsequent request resends the history, every following message in that session fails, even after the original problem (e.g. a bad endpoint) is fixed — because llama-server's /apply-template validation rejects the whole request the moment it sees a message with no role.

## Fix

Add `role: 'assistant'` to the fallback message so it is always a valid chat message:

```typescript

private createErrorResponse(error: LlamaApiError): LlamaToolsResponse {
        return {
            choices: [{
                message: { role: 'assistant', content: error.message },
                finish_reason: 'error',
                error,
            }],
            error,
        };
    }

```

## Testing

- Reproduced the bug by pointing llama-vscode.endpoint_tools at an invalid endpoint (e.g. http://localhost:9999999) and sending a prompt in the Agent panel.

- Confirmed the first request fails as expected.

- Sent a second prompt in the same session and confirmed it no longer fails due to a missing-role entry in history.

- Confirmed normal (non-error) request/response flow is unaffected.