### PR TITLE
Scripts for llama-vscode are introduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -1615,7 +1615,12 @@
         "llama-vscode.skills_folder": {
           "type": "string",
           "default": "",
-          "description": "The folder, where are the skills are stored. If empty , <project_folder>/skills will be used."
+          "description": "The folder, where the skills are stored. If empty , <project_folder>/skills will be used."
+        },
+        "llama-vscode.scripts_folder": {
+          "type": "string",
+          "default": "",
+          "description": "The folder, where llama-vscode scripts are stored."
         },
         "llama-vscode.language": {
           "type": "string",

--- a/resources/help.md
+++ b/resources/help.md
@@ -1,12 +1,21 @@
 ## Agent commands
 
 ### What are agent commands
-Agent commands are a way to reuse often used prompts. They could be used to describe complex workflows or for simple instructions.   
-Agent commands are stored in setting agent_commands and llama-vscode menu item "Agent commands..." could be used to manage them.
+There are two types of agent commands:  
+
+#### Prompt commands
+Prompt commands send prompt to the agent (no prompt to the agent: false). They are a way to reuse often used prompts. They could be used to describe complex workflows or for simple instructions. If scripts are used, they should return the prompt, which will be sent to the agent. Skills are logically prompt commands and in the future versions they will be considered as agent prompt commands (but not yet).
+
+#### Script commands
+Script commands do not send prompt to the agent (no prompt to the agent: true, is script: true). They are actions within llama-vscode and could automate some tasks. For example select models, agents, change settings, etc.. The content of the command is intepreted as a [script](https://github.com/ggml-org/llama.vscode/wiki/Scripts) and is executed. All script files with suffix .lvs in the scripts_folder are considered as agent script commands and are shown on entering "/" in the agent prompt field.
+
+Agent commands are stored in setting agent_commands and llama-vscode menu item "Agent commands..." could be used to manage them.  
 The command prompt could contain terminal commands in format !'<terminal_command>' (as in claude code.). The command prompt is preprocessed and the terminal commands are executed and replaced with the the result of the execution. Example: !'pwd' will be replaced with the the current directory.
 
+The prompt field of the command could be a path to a file. Before executing the command, the file is read and the content is used as the prompt field value. The file cold contain a prompt or a script.
+
 ### How to use them
-Prerequisite: tools model is selected.
+Prerequisite for prompt commands: tools model is selected  
 You could create agent commands from llama-vscode menu item "Agent commands..."\"Add agent command...". For creating a command with longer prompts you could export an existing command with "Agent commands..."\"Export agent command..." in a .json file, change the name and the prompt in the file and then import the new command with "Agent commands..."\"Import agent command...". 
 
 In agent prompt text area press "/" - the available agent commands will be shown and could be selected. When selected, the command name is replaced with the longer prompt for this command and is sent to the AI model.  
@@ -297,13 +306,22 @@ Settings:
 <img width="580" height="779" alt="image" src="https://github.com/user-attachments/assets/bb29e0c8-85b4-4e7a-a3d9-f2d9a1679d3d" />
 
 
+## Version 0.0.59 is released (07.08.2026)
+### What is new
+- [Scripts](https://github.com/ggml-org/llama.vscode/wiki/Scripts) are introduced - something like macroses for llama-vscode. Scripts are written in a simple DSL language, which supports execution of llama-vscode commands for selecting/deselecting models, agent, env, changing settings, executing terminal commands etc. The scripts also support variables, if/else statements and comments. The scripts could be used as a content of the agent commands (agent commands are shown by pressing / in the agent prompt field). The plan is in future the scripts to be used in the hooks (not yet introduced)
+- The agent commands, which send prompt to the agent are now visualized with [p] preffix, while those, which execute scripts and do not send prompt are visualized with [s] preffix.
+- New setting scripts_folder - the files in this folder with extension .lvs are considered as agent script commands and are shown on entering "/" in the agent prompt field. Those commands do not send prompt to the agent.
+- More informative errors in case of problems with code completion.
+- Telegram bot - the /chat command for showing the current chat (last xx chars) is availabe even while the agent is running.
+
+
 ## Version 0.0.58 is released (03.08.2026)
-## What is new
+### What is new
 - New agent commands were added - disable_completions, enable_completions, disable_rag, enable_rag, select_help_agent, select_tools_model_kimi_k3 (Kimi K3 tools on demand), etc.
 
 
 ## Version 0.0.57 is released (31.07.2026)
-## What is new
+### What is new
 - Telegram bot - new commands /tools, /addtools, /removetools [More details](https://github.com/ggml-org/llama.vscode/wiki/Telegram-bot)
 - Telegram bot - user confirmation of terminal commands, changing or deleting files is now possible from Telegram. [More details](https://github.com/ggml-org/llama.vscode/wiki/Telegram-bot)
 - Deep links support added. Now VS Code and and a llama-vscode view could be opened from a link. Example [vscode://ggml-org.llama-vscode?view=agent&prompt=Hello](vscode://ggml-org.llama-vscode?view=agent&prompt=Hello) opens VS Code and llama-vscode agent and writes in the prompt box "Hello". [More details](https://github.com/ggml-org/llama.vscode/wiki/Deep-link)
@@ -313,26 +331,26 @@ Settings:
 
 
 ## Version 0.0.56 is released (27.07.2026)
-## What is new
+### What is new
 - Telegram bot commands exteded and simplified. [More details](https://github.com/ggml-org/llama.vscode/wiki/Telegram-bot)
 - Agent commands prompt could now include terminal commands in format !'<terminal_command>'. The prompt is preprocessed - the commands are executed and replaced with the result of the execution in the prompt.
 - Kimi K3 - dynamically loaded tools (tools on demand) fix - prevent sending the same tool definition several times.
 
 
 ## Version 0.0.55 is released (24.07.2026)
-## What is new
+### What is new
 - Now you could access your llama-vscode agents from your phone with a Telegram bot. [More details](https://github.com/ggml-org/llama.vscode/wiki/Telegram-bot)
 
 
 ## Version 0.0.54 is released (19.07.2026)
-## What is new
+### What is new
 - Added predefined kimi k3 tools models for OpenRouter and moonshot.ai
 - Implemented dynamically loaded tools (tools on demand) feature for Kimi K3 (works only for moonshot.ai). This optimizes the token usage and reduces the price of using kimi k3. [More details]( https://platform.kimi.ai/docs/guide/use-dynamic-tool-loading)
 - Added predefined copilot agent (uses system prompt based on VS Code copilot system prompt)
 
 
 ## Version 0.0.53 is released (16.07.2026)
-## What is new
+### What is new
 
 - New setting rag_ignore_file for excluding files/folders from RAG indexing
 - Fix for showing Chat with AI window inside VS Code
@@ -340,7 +358,7 @@ Settings:
 
 
 ## Version 0.0.52 is released (13.07.2026)
-## What is new
+### What is new
 
 - New tool get_errors for getting file or project errors (prompts reused from copilot)
 - New tool rename_symbol for renaming a symbol (variable, function, etc. in the whole project) (prompts reused from copilot)
@@ -348,7 +366,7 @@ Settings:
 
 
 ## Version 0.0.51 is released (28.06.2026)
-## What is new
+### What is new
 
 - Agent UI is changed - a button is added for sending a prompt during agent loop (entering text and Enter has the same effect)
 - If a prompt is sent during the agent loop - the LLM receives it at earliest possible time
@@ -356,7 +374,7 @@ Settings:
 
 
 
-## Version 0.0.50 is released (26.06.2026)
+### Version 0.0.50 is released (26.06.2026)
 ## What is new
 
 * Option for using standard shell script for llama.cpp installation (brew / winget also available)
@@ -969,6 +987,41 @@ The rules are optional. You could use rules file to add instructions to the syst
 There are two ways to configure rules:
 - Create a new rules file under name llama-vscode-rules.md in the root of the project.
 - In llama-vscode setting Agent_rules enter a path to a rules file. It could be relative to the project root or absolute path. If this is specified, the file llama-vscode-rules.md will be ignored.
+## Scripts
+
+### Overview
+Llama-vscode supports scripts. Scripts are actions within llama-vscode and could automate some tasks. For example select models, agents, change settings, etc... The scripts are in a simple language (DSL), which supports execution of llama-vscode commands, variables and if/else statements. However, the language is very simple and doesn't support the feature of the modern programming languages. It is just for automating llama-vscode tasks. They are similar to macroses in Excel (or Office applications).
+
+Example script:
+```
+set maxParallelCompl getSetting max_parallel_completions
+if $maxParallelCompl > 3
+  setSetting max_parallel_completions 3
+endif
+
+if $maxParallelCompl < 1
+  setSetting max_parallel_completions 1
+endif
+
+return The parallel completions are set in correct range
+```
+
+Variables: Use set to set varName value (no need to define them). value could be a llama-vscode command (as in the above script). User $varName to get the value. Variables have no types for now. They are represented internally as strings. However, in the if statement, if the values of the both operands are numbers, the comaprison is done as a comparison of numbers.
+
+llama-vscode commands: Some examples are getSetting <setting_name>, setSetting <setting_name> <value> setToolsModel <model_name>, setCompletionModel <model_name>, setEnv <env_name>, deselectToolsModel, deselectCompletionModel, runTerminalCommand <command>, etc.
+
+if else endif: As is visible from the example above, there are no brackets, but endif is required. The if condition supports comparison operators (>, <, ==, !=, >=, <=), but just one (and, or, not are not supported).
+
+Comments: The lines starting with // are comments and are ignored during execution.
+
+### How to use it
+For example the scripts could be used in agent commands. If the field "is script" of the agent command is true, the content of the prompt field of the agent command is interpreted as script is executed. If the prompt contains a path to a file, the content of the file is executed.
+
+
+Settings:
+-  scripts_folder: The folder where the script files are searched by default. All script files with suffix .lvs are considered agent script commands and are shown on entering "/" in the agent prompt field. Those commands do not send prompt to the agent.
+
+
 ## Setup llama.cpp server for Linux 
 
 Make sure you have brew package manager installed (from https://brew.sh/). You could install brew with the command 
@@ -1200,15 +1253,15 @@ CPU-only:
 With Nvidia GPUs and installed cuda drivers  
 - more than 16GB VRAM  
 ```bash
-`llama serve.exe -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011`  
+`llama serve.exe -hf qwen2.5-coder-7b-instruct-q8_0.gguf --port 8011 -np 2`  
 ```
 - less than 16GB VRAM  
 ```bash
-`llama serve.exe -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011`  
+`llama serve.exe -hf qwen2.5-coder-3b-instruct-q8_0.gguf --port 8011 -np 2`  
 ```
 - less than 8GB VRAM  
 ```bash
-`llama serve.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011` 
+`llama serve.exe -hf qwen2.5-coder-1.5b-instruct-q8_0.gguf --port 8011 -np 2` 
 ```
 
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -2,6 +2,7 @@ import {Application} from "./application";
 import { LlamaResponse } from "./types";
 import vscode from "vscode";
 import {Utils} from "./utils";
+import { isAxiosError } from "axios";
 
 interface CompletionDetails {
     completions: string[];
@@ -145,7 +146,16 @@ export class Completion {
             if (err instanceof Error) {
                 vscode.window.showInformationMessage(err.message);
                 errorMessage = err.message
+                if (isAxiosError(err) && err.response?.data?.error?.message) {
+                    // Field 'n_cmpl': Value must be between 1 <= value <= 4, but got 7
+                    let dataErrMsg = err.response?.data?.error?.message
+                    if (dataErrMsg.startsWith("Field 'n_cmpl': Value must be between")) dataErrMsg +='; Set setting Max_parallel_completions within the range for n_cmpl.'
+                    vscode.window.showInformationMessage(dataErrMsg);
+                    errorMessage += " " + dataErrMsg;
+                }
+                
             }
+             
             this.isRequestInProgress = false
             this.app.logger.addEventLog(group, "ERROR_RETURN", errorMessage)
             return [];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -49,6 +49,7 @@ export class Configuration {
     ring_scope = 1024;
     ring_update_ms = 1000;
     skills_folder = ""
+    scripts_folder = ""
     language = "en";
     health_check_interval_s = 30;
     health_check_compl_enabled = false;
@@ -281,6 +282,7 @@ export class Configuration {
         this.lm_max_output_tokens = Number(config.get<number>("lm_max_output_tokens"));
         this.popup_max_chars = Number(config.get<number>("popup_max_chars"));
         this.skills_folder = String(config.get<string>("skills_folder"));
+        this.scripts_folder = String(config.get<string>("scripts_folder"));
         this.language = String(config.get<string>("language"));
         this.disabledLanguages = config.get<string[]>("disabledLanguages") || [];
         this.enabled = Boolean(config.get<boolean>("enabled", true));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,6 +90,12 @@ export enum AGENT_NAME {
   llamaVscodeHelp = 'llama-vscode help'
 }
 
+export const AGENT_COMMAND = {
+  scrip_file_suffix: '.lvs',
+  type_preffix_script: 's', //should be one character
+  type_preffix_prompt: 'p' //should be one character
+}
+
 export const UI_TEXT_KEYS = {
   // Agent command texts
   enterName: "Enter agent command name",
@@ -367,4 +373,4 @@ export const SUPPORTED_IMG_FILE_EXTS: { [key: string]: string } = {
     '.jpg': 'image/jpeg',
     '.png': 'image/png',
     '.webp': 'image/webp'
-} as const;;
+} as const;

--- a/src/dsl-commands.ts
+++ b/src/dsl-commands.ts
@@ -1,7 +1,8 @@
 import {Application} from "./application";
 import { ModelType, PREDEFINED_LISTS_KEYS } from "./constants";
 import { PREDEFINED_LISTS } from "./lists";
-import { Agent, LlmModel } from "./types";
+import { Agent, Env, LlmModel } from "./types";
+import { Utils } from "./utils";
 
 type CommandsMap = Map<string, (...args: any[]) => any>;
 
@@ -47,7 +48,6 @@ export class DslCommands {
         this.commandsFunc.set("addcontextimage", this.addContextImage);
         this.commandsFunc.set("removecontextimage", this.removeContextImage);
         this.commandsFunc.set("executecommand", this.executeCommand);
-        this.commandsFunc.set("executeterminalcommand", this.executeTerminalCommand);
         this.commandsFunc.set("addapikey", this.addApiKey);
         this.commandsFunc.set("deleteapikey", this.deleteApiKey);
         this.commandsFunc.set("installupgradellamacpp", this.installUpgradeLlamaCpp);
@@ -73,15 +73,37 @@ export class DslCommands {
         this.commandsFunc.set("removeagent", this.removeAgent);
         this.commandsFunc.set("exportagent", this.exportAgent);
         this.commandsFunc.set("importagent", this.importAgent);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
-        this.commandsFunc.set("run_terminal_command", this.setToolsModel);
+        this.commandsFunc.set("runterminalcommand", this.runTerminalCommand);
+        this.commandsFunc.set("showinfo", this.showInfo);
+        this.commandsFunc.set("compact", this.compact);
     }
 
+    public compact = async() => {
+        // TODO Fix summarizeToFitCurrentBudget, doesn't work for now
+        const isSummarized = await this.app.llamaAgent.summarizeToFitCurrentBudget()
+        let result = "Chat is not compacted."
+        if (isSummarized) result = "Chat is compacted"
+        return result
+    }
+
+    public stripArgumentValue = (argument: string): string => {
+        if (argument.startsWith('"') && argument.endsWith('"')) {
+            return argument.slice(1, -1);
+        }
+        if (argument.startsWith("'") && argument.endsWith("'")) {
+            return argument.slice(1, -1);
+        }
+        if (argument.startsWith('`') && argument.endsWith('`')) {
+            return argument.slice(1, -1);
+        }
+        return argument;
+    }
+
+    public runTerminalCommand = async (command: string) => {
+        let {stdout, stderr} = await this.app.llamaServer.executeCommandWithTerminalFeedback(command);
+        return (stdout + "\n\n" + stderr).slice(0, this.app.configuration.MAX_CHARS_TOOL_RETURN);
+    }
+    
     public  setToolsModel = async (modelName: string) => {
         return await this.setModel(ModelType.Tools, modelName);
     }
@@ -98,31 +120,47 @@ export class DslCommands {
         return await this.setModel(ModelType.Embeddings, modelName);
     }
 
-    public setEnv = async (args: string) => {
-        return "Not implemented"
+    public setEnv = async (envName: string) => {
+        let result = ""
+        envName = this.stripArgumentValue(envName)
+        let allEnvs = this.app.configuration.envs_list
+            .concat((PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.ENVS) as Env[]))
+        const env = allEnvs.find((env) => env.name === envName);
+        if (env) {
+            this.app.envService.selectStartEnv(env, true)
+            result = `Env ${envName} is selected.`
+        } else {
+            result = `Env ${envName} is not found.`
+        }
+        
+        return result
     }
 
-    public deselectToolsModel = async (args: string) => {
-        return "Not implemented"
+    public deselectToolsModel = async () => {
+        return await this.deselectModel(ModelType.Tools);
     }
 
     public deselectCompletionModel = async (args: string) => {
-        return "Not implemented"
+        return await this.deselectModel(ModelType.Completion);
     }
 
     public deselectEmbeddigsModel = async (args: string) => {
-        return "Not implemented"
+        return await this.deselectModel(ModelType.Embeddings);
     }
 
     public deselectChatModel = async (args: string) => {
-        return "Not implemented"
+        return await this.deselectModel(ModelType.Chat);
+    }
+
+    
+
+    public deselectEnv = async (args: string) => {
+        await this.app.envService.stopEnv();
+
+        return `Env is deselected (stopped)`
     }
 
     public addToolsModel = async (args: string) => {
-        return "Not implemented"
-    }
-
-    public deselectEnv = async (args: string) => {
         return "Not implemented"
     }
 
@@ -226,10 +264,6 @@ export class DslCommands {
         return "Not implemented"
     }
 
-    public executeTerminalCommand = async (args: string) => {
-        return "Not implemented"
-    }
-
     public addApiKey = async (args: string) => {
         return "Not implemented"
     }
@@ -270,22 +304,31 @@ export class DslCommands {
     public log = async (args: string) => {
         return "Not implemented"
     }
+
+    public showInfo = async (msg: string) => {
+        await this.app.dialogs.showOkDialog(msg)
+        return "Info is shown"
+    }
     
     public setSetting = async (args: string) => {
         const splitIndex = args.indexOf(" ")
-        const settingName = args.slice(0, splitIndex)
+        let settingName = args.slice(0, splitIndex).trim().toLowerCase()
         
-        const settingValue = args.slice(splitIndex + 1)
-        // TODO Get the setting from setting name and get the type - check for types instead for settings
-        if (settingName.toLowerCase() === "enabled"
-            ||settingName.toLowerCase() === "rag_enabled") await this.app.configuration.updateConfigValue(settingName, settingValue.toLowerCase() == "true")
+        let settingValue = args.slice(splitIndex + 1)
+        settingName = this.stripArgumentValue(settingName)
+        settingValue = this.stripArgumentValue(settingValue)
+            
+        const value = this.getPropertyType(this.app.configuration, settingName as keyof typeof this.app.configuration);
+        if (typeof value == "boolean") await this.app.configuration.updateConfigValue(settingName, settingValue.toLowerCase() == "true")
+        else if (typeof value == "number") await this.app.configuration.updateConfigValue(settingName, Number(settingValue))
         else await this.app.configuration.updateConfigValue(settingName, settingValue)
         
         return `Setting ${settingName} is set to ${settingValue}`
     }
 
-    public getSetting = async (args: string) => {
-        return "Not implemented"
+    public getSetting = async (settingName: string) => {
+        const setting = this.app.configuration[settingName.trim().toLowerCase() as keyof typeof this.app.configuration]
+        return setting
     }
 
     public setChat = async (args: string) => {
@@ -317,6 +360,7 @@ export class DslCommands {
     }
 
     public setAgent = async (agentName: string) => {
+        agentName = this.stripArgumentValue(agentName)
         const agent = this.getAllAgentsList().find((agnt) => agnt.name === agentName);;
         let response = ""
         if (agent) {
@@ -349,7 +393,14 @@ export class DslCommands {
         return "Not implemented"
     }
 
+    private async deselectModel(modelType: ModelType) {
+        await this.app.modelService.deselectAndClearModel(modelType);
+
+        return `The model for ${modelType} is deselected/stopped`;
+    }
+
     private async setModel(modelType: ModelType, modelName: string) {
+        modelName = this.stripArgumentValue(modelName)
         const model = this.getAllModelsList(modelType).find((model) => model.name === modelName);
         let result = "";
         if (model) {
@@ -390,5 +441,9 @@ export class DslCommands {
     private getAllAgentsList(): Agent[] {
             return this.app.configuration.agents_list
                     .concat((PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.AGENTS) as Agent[]))
-        }
+    }
+
+    private getPropertyType<T, K extends keyof T>(obj: T, key: K): T[K] {
+        return obj[key];
+    }
 }

--- a/src/dsl-interpreter.ts
+++ b/src/dsl-interpreter.ts
@@ -10,12 +10,27 @@ export class DslInterpreter {
     execute = async (script: string): Promise<any> => {
         const commandsMap = this.app.dslCommands.commandsFunc;
 
-        // Execution context. For now it only keeps the result of the last
-        // executed command, but it is designed to be extended with variables
-        // and operator state in the future.
-        const context: { lastResult?: any; variables: Map<string, any> } = {
+        // Execution context with variables and the stack of conditional blocks.
+        // Each control frame describes one enclosing `if` block:
+        //   ifTaken - the `if` condition evaluated to true
+        //   elseSeen - an `else` for this block was already encountered
+        //   active  - lines in the current section of this block should execute
+        interface ControlFrame {
+            ifTaken: boolean;
+            elseSeen: boolean;
+            active: boolean;
+        }
+        const context: { lastResult?: any; variables: Map<string, any>; conditionStack: ControlFrame[] } = {
             lastResult: undefined,
-            variables: new Map<string, any>()
+            variables: new Map<string, any>(),
+            conditionStack: []
+        };
+
+        // Helper function to substitute variables in a string
+        const substituteVariables = (str: string): string => {
+            return str.replace(/\$(\w+)/g, (_, varName) => {
+                return `"${context.variables.get(varName) || ''}"` ;
+            });
         };
 
         // Each command is on a separate line.
@@ -24,24 +39,144 @@ export class DslInterpreter {
         for (const rawLine of lines) {
             const line = rawLine.trim();
 
-            // Skip empty lines.
-            if (line.length === 0) {
+            // Skip empty lines and comment lines.
+            if (line.length === 0 || line.trim().startsWith("//")) {
                 continue;
             }
 
-            // Handle "return" statement: the value after return is returned
-            // from the execute method and the script execution stops.
-            if (line === "return" || line.startsWith("return ")) {
-                const returnValue = line.slice("return".length).trim();
-                return returnValue;
+            const isIf = line.startsWith('if ');
+            const isElse = line === 'else' || line.startsWith('else ');
+            const isEndif = line === 'endif' || line.startsWith('endif ');
+
+            // Handle the if/else/endif control-flow commands first so they are
+            // processed both when the current block is active and when it is
+            // being skipped.
+            if (isIf) {
+                // Handle if conditions. A nested `if` that appears while its
+                // enclosing block is skipped simply pushes a non-active frame
+                // so that its matching `else`/`endif` are tracked correctly.
+                const parentActive = context.conditionStack.every((frame) => frame.active);
+                const condition = line.substring(3).trim();
+                const substitutedCondition = substituteVariables(condition);
+                const parts = substitutedCondition.match(/(".*?"|'.*?'|`.*?`|\S+)/g) || [];
+
+                if (parts.length !== 3) {
+                    throw new Error('Invalid if condition syntax. Use: if $var == "value" (quotes required for spaces)');
+                }
+
+                const left = parts[0].replace(/^["'`]|["]$|['`]$|[`]$/g, '');
+                const operator = parts[1];
+                const right = parts[2].replace(/^["'`]|["]$|['`]$|[`]$/g, '');
+                
+                const areOperandsNumbes = Number(left) && Number(right)
+                const leftOperand = areOperandsNumbes ? Number(left) : left
+                const rightOperand = areOperandsNumbes ? Number(right) : right
+                let conditionResult = false;
+                switch (operator) {
+                    case '==':
+                        conditionResult = leftOperand === rightOperand;
+                        break;
+                    case '!=':
+                        conditionResult = leftOperand !== rightOperand;
+                        break;
+                    case '>':
+                        conditionResult = leftOperand > rightOperand;
+                        break;
+                    case '>=':
+                        conditionResult = leftOperand >= rightOperand;
+                        break;
+                    case '<':
+                        conditionResult = leftOperand < rightOperand;
+                        break;
+                    case '<=':
+                        conditionResult = leftOperand <= rightOperand;
+                        break;
+                    default:
+                        throw new Error(`Unsupported operator in if condition: ${operator}`);
+                }
+
+                context.conditionStack.push({
+                    ifTaken: parentActive && conditionResult,
+                    elseSeen: false,
+                    active: parentActive && conditionResult
+                });
+                continue;
             }
 
-            await this.executeLine(line, commandsMap, context);
+            if (isElse) {
+                const frame = context.conditionStack[context.conditionStack.length - 1];
+                if (!frame) {
+                    throw new Error('Syntax error: "else" without a matching "if"');
+                }
+                if (frame.elseSeen) {
+                    throw new Error('Syntax error: multiple "else" for the same "if"');
+                }
+                frame.elseSeen = true;
+                // The else branch runs only when the `if` condition was false.
+                frame.active = !frame.ifTaken;
+                continue;
+            }
+
+            if (isEndif) {
+                if (context.conditionStack.length === 0) {
+                    throw new Error('Syntax error: "endif" without a matching "if"');
+                }
+                context.conditionStack.pop();
+                continue;
+            }
+
+            // Skip the lines that are inside a non-active conditional block.
+            if (context.conditionStack.some((frame) => !frame.active)) {
+                continue;
+            }
+
+            // Handle "return" statement with variable substitution
+            if (line === "return" || line.startsWith("return ")) {
+                const returnValue = line.slice("return".length).trim();
+                const substitutedValue = substituteVariables(returnValue);
+                return substitutedValue;
+            }
+
+            // Handle variable assignment
+            if (line.startsWith('set ')) {
+                const args = line.substring(4).trim();
+                const [varName, ...valueParts] = args.split(' ');
+                const valueCommand = valueParts.join(' ');
+                
+                if (valueCommand) {
+                    // Substitute variables in the command first
+                    const substitutedCommand = substituteVariables(valueCommand);
+                    // Execute the command and capture result
+                    let result = ""
+                    if (!commandsMap.get(substitutedCommand.split(" ")[0].toLowerCase())){
+                        result = this.app.dslCommands.stripArgumentValue(substitutedCommand)
+                    } else {
+                        result = await this.executeLine(substitutedCommand, commandsMap, context);
+                    }
+                    context.variables.set(varName, result);
+                } else {
+                    context.variables.set(varName, '');
+                }
+                continue;
+            }
+
+            // For regular commands, substitute variables and execute
+            const substitutedLine = substituteVariables(line);
+            try {
+                await this.executeLine(substitutedLine, commandsMap, context);
+            } catch (err){
+                if (err instanceof Error){
+                    console.log(err.message)
+                    return err.message
+                } 
+            }
         }
 
-        // If there was only one command (line), the return value of this
-        // command is the return value of the script. For multiple commands,
-        // the result of the last executed command is returned.
+        if (context.conditionStack.length > 0) {
+            throw new Error('Syntax error: missing "endif" for an "if" block');
+        }
+
+        // Return the last result if no explicit return
         return context.lastResult;
     }
 

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -1213,5 +1213,15 @@ export const PREDEFINED_LISTS = new Map<string, any>([
               "noPrompt": true,
               "isScript": true
             },
+            {
+              "name": "select_env_only_compl_cpu",
+              "prompt": [
+                "setEnv Local, only completions - CPU (HD: 1.6 GB)"
+              ],
+              "description": "Selectsenv - only comletions - CPU (HD: 1.6 GB)",
+              "noPrompt": true,
+              "isScript": true
+            },
+            
           ]],
 ])

--- a/src/llama-agent.ts
+++ b/src/llama-agent.ts
@@ -5,7 +5,7 @@ import { Utils } from "./utils"
 import { Chat } from "./types"
 import { Plugin } from './plugin';
 import * as fs from 'fs';
-import { PREDEFINED_LISTS_KEYS, SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
+import { AGENT_COMMAND, PREDEFINED_LISTS_KEYS, SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
 import path from "path";
 import { DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS, resolveBoundedMaxOutputTokens } from './language-model-token-limits';
 import { PREDEFINED_LISTS } from "./lists";
@@ -279,7 +279,7 @@ export class LlamaAgent {
         }
     }
 
-    private async summarizeToFitCurrentBudget(imagePath = ""): Promise<boolean> {
+    public async summarizeToFitCurrentBudget(imagePath = ""): Promise<boolean> {
         const tokenLimits = await this.app.llamaServer.getToolsModelTokenLimits();
         const reservedOutputTokens = Math.max(1024, resolveBoundedMaxOutputTokens({
             maxInputTokens: tokenLimits.maxInputTokens,
@@ -334,7 +334,21 @@ export class LlamaAgent {
             if (agentCommand) {
                 let commands = this.app.configuration.agent_commands as AgentCommand[];
                 commands = commands.concat(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.AGENT_COMMANDS) as AgentCommand[])
-                const commandDetails = commands.find( cmd => cmd.name === agentCommand)     
+                let commandDetails = commands.find( cmd => cmd.name === agentCommand)
+                if (!commandDetails 
+                    && agentCommand.toLowerCase().endsWith(AGENT_COMMAND.scrip_file_suffix)){
+                    const scriptFilePath = path.join(this.app.configuration.scripts_folder, agentCommand)
+                    if (fs.existsSync(scriptFilePath)) {
+                        const script = fs.readFileSync(scriptFilePath, 'utf-8')              
+                        commandDetails = {
+                            name: "script",
+                            description: "Run a script file",
+                            prompt: [script],
+                            isScript: true,
+                            noPrompt: true,
+                        }
+                    }
+                }     
                 if (commandDetails) {     
                     let prompt =  commandDetails.prompt.join("\n")
                     if (Utils.isFilePath(prompt))

--- a/src/llama-webview-provider.ts
+++ b/src/llama-webview-provider.ts
@@ -6,7 +6,7 @@ import { LlmModel, Env, Agent, ContextCustom, AgentCommand } from './types';
 import { Configuration } from './configuration';
 import { Plugin } from './plugin';
 import { Utils } from './utils';
-import { ModelType, PREDEFINED_LISTS_KEYS, SETTING_NAME_FOR_LIST } from './constants';
+import { AGENT_COMMAND, ModelType, PREDEFINED_LISTS_KEYS, SETTING_NAME_FOR_LIST } from './constants';
 import { PREDEFINED_LISTS } from './lists';
 
 export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
@@ -119,7 +119,8 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
     }
 
     sendAgentCommand = async (message: any, webviewView: vscode.WebviewView) => {
-        this.app.llamaAgent.run(message.text, message.agentCommand)
+        const agentCommand = this.app.agentCommandService.removePreffix(message.agentCommand)
+        this.app.llamaAgent.run(agentCommand, agentCommand)
     }
 
     sendInSessionText = async (message: any, webviewView: vscode.WebviewView) => {
@@ -289,16 +290,8 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
     }
     
     getAgentCommands = async (message: any, webviewView: vscode.WebviewView) => {
-        let commands =  this.app.configuration.agent_commands
-        commands = commands.concat(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.AGENT_COMMANDS) as AgentCommand[])
+        const agentCommands = this.app.agentCommandService.getAgentCommandsList()
         
-        if (this.app.configuration.enabled) commands = commands.filter(cmd => cmd.name != "enable_completions")
-        else commands = commands.filter(cmd => cmd.name != "disable_completions")
-        
-        if (this.app.configuration.rag_enabled) commands = commands.filter(cmd => cmd.name != "enable_rag")
-        else commands = commands.filter(cmd => cmd.name != "disable_rag")
-        
-        let agentCommands =  commands.map(cmd => cmd.name +  " | " + cmd.description)
         webviewView.webview.postMessage({
             command: 'updateFileList',
             files: agentCommands

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -2,7 +2,9 @@ import {Application} from "./application";
 import vscode, { QuickPickItem } from "vscode";
 import os from "os";
 import { Utils } from "./utils";
-import { ModelType, AGENT_NAME, UI_TEXT_KEYS, UiView } from "./constants";
+import { ModelType, AGENT_NAME, UI_TEXT_KEYS, UiView, PREDEFINED_LISTS_KEYS } from "./constants";
+import { PREDEFINED_LISTS } from "./lists";
+import { Agent } from "./types";
 
 export class Menu {
     private app: Application
@@ -342,7 +344,9 @@ export class Menu {
                 this.showHowToUseLlamaVscode();
                 break;
             case this.app.configuration.getUiText(UI_TEXT_KEYS.chatWithAIAboutLlamaVscode):
-                const helpAgent = this.app.configuration.agents_list.find(a => a.name === AGENT_NAME.llamaVscodeHelp);
+                const allAgents = this.app.configuration.agents_list
+                    .concat(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.AGENTS) as Agent[])
+                const helpAgent = allAgents.find(a => a.name === AGENT_NAME.llamaVscodeHelp);
                 if (helpAgent) {
                     await this.app.agentService.selectAgent(helpAgent);
                 }

--- a/src/services/agent-command-service.ts
+++ b/src/services/agent-command-service.ts
@@ -5,7 +5,7 @@ import { Agent, AgentCommand } from "../types";
 import { Utils } from "../utils";
 import * as fs from 'fs';
 import * as path from 'path';
-import { PREDEFINED_LISTS_KEYS, SETTING_NAME_FOR_LIST, UI_TEXT_KEYS } from "../constants";
+import { AGENT_COMMAND, PREDEFINED_LISTS_KEYS, SETTING_NAME_FOR_LIST, UI_TEXT_KEYS } from "../constants";
 import { PREDEFINED_LISTS } from "../lists";
 
 export class AgentCommandService {
@@ -33,6 +33,17 @@ export class AgentCommandService {
                 label: this.app.configuration.getUiText(UI_TEXT_KEYS.importAgentCommand) ?? ""
             },
         ];
+    }
+
+    removePreffix = (agentCommandName: string): string => {
+        let strippedCommand = agentCommandName;
+        if (agentCommandName.startsWith(`[${AGENT_COMMAND.type_preffix_script}]`)) {
+            strippedCommand = agentCommandName.slice(`[${AGENT_COMMAND.type_preffix_script}]`.length);
+        } else if (agentCommandName.startsWith(`[${AGENT_COMMAND.type_preffix_prompt}]`)) {
+            strippedCommand = agentCommandName.slice(`[${AGENT_COMMAND.type_preffix_prompt}]`.length);
+        }
+
+        return strippedCommand;
     }
 
     async processActions(selected: QuickPickItem): Promise<void> {
@@ -71,14 +82,28 @@ export class AgentCommandService {
         if (!name) return;
 
         const command = await vscode.window.showInputBox({
-            prompt: "Enter the command",
-            validateInput: (value) => value ? null : "Command is required"
+            prompt: "Enter path to the file with prompt/script (or prompt/scrip)",
+            validateInput: (value) => value ? null : "file path/or text value is required"
         });
         if (!command) return;
 
+        const notPrompt = await vscode.window.showInputBox({
+            prompt: "Does this command send a prompt to the agent? Answer with yes or no (y or n is also OK)",
+            validateInput: (value) => value ? null : "Answer is required"
+        });
+        if (!notPrompt) return;
+        const isNotPrompt = notPrompt.trim().toLocaleLowerCase() == "no" || notPrompt.trim().toLocaleLowerCase() == "n"
+
+        const isScriptAns = await vscode.window.showInputBox({
+            prompt: "Is it script (i.e. not prompt)? Answer with yes or no (y or n is also OK)",
+            validateInput: (value) => value ? null : "Answer is required"
+        });
+        if (!isScriptAns) return;
+        const isScript = isScriptAns.trim().toLocaleLowerCase() == "yes" || isScriptAns.trim().toLocaleLowerCase() == "y"
+
         const description = await vscode.window.showInputBox({ prompt: "Enter description (optional)" });
 
-        const newCommand: AgentCommand = { name, prompt: [command], description: description || "" };
+        const newCommand: AgentCommand = { name, prompt: [command], description: description || "", noPrompt: isNotPrompt, isScript: isScript };
         await this.persistAgentCommandToSetting(newCommand, this.app.configuration.agent_commands, settingName);
     }
 
@@ -114,6 +139,25 @@ export class AgentCommandService {
         await this.app.dialogs.showOkDialog(
             this.getAgentCommandDetailsAsString(selectedAgentCommand)
         );
+    }
+
+    getAgentCommandsList = () => {
+        let commands =  this.app.configuration.agent_commands as AgentCommand[]
+        commands = commands.concat(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.AGENT_COMMANDS) as AgentCommand[]) as AgentCommand[]
+        
+        if (this.app.configuration.enabled) commands = commands.filter(cmd => cmd.name != "enable_completions")
+        else commands = commands.filter(cmd => cmd.name != "disable_completions")
+        
+        if (this.app.configuration.rag_enabled) commands = commands.filter(cmd => cmd.name != "enable_rag")
+        else commands = commands.filter(cmd => cmd.name != "disable_rag")
+        
+        let agentCommands =  commands.map(cmd => `[${cmd.noPrompt?AGENT_COMMAND.type_preffix_script:AGENT_COMMAND.type_preffix_prompt}]${cmd.name} | ${cmd.description}`)
+        
+        const scriptsFolder = path.join(this.app.configuration.scripts_folder, "")
+        let scriptCommands = fs.readdirSync(scriptsFolder, { withFileTypes: true }).filter(dirent => dirent.isFile() && dirent.name.toLowerCase().endsWith(".lvs")).map(dirent => `[${AGENT_COMMAND.type_preffix_script}]${dirent.name}`)
+        agentCommands = agentCommands.concat(scriptCommands)
+        
+        return agentCommands;
     }
 
     private async persistAgentCommandToSetting(newAgentCommand: AgentCommand, agentCommands: any[], settingName: string) {

--- a/src/telegram-bot.ts
+++ b/src/telegram-bot.ts
@@ -59,7 +59,22 @@ export class TelegramBot {
         if (!receivedMessage 
             || receivedMessage == "/start") {
                 return;
+        }
+
+        if (receivedMessage.toLowerCase().startsWith(TELEGRAM_BOT_COMMANDS.SHOW_CHAT)){
+            const chatSize = receivedMessage.split(" ")[1];
+            let maxChatChars = 1000
+            if (chatSize){
+                maxChatChars = Number(chatSize);
+                if (isNaN(maxChatChars)) {
+                    maxChatChars = 1000;
+                }
             }
+            const msgChat = this.app.configuration.getUiText(UI_TEXT_KEYS.telegramCurrentChat) + " \n" + this.app.llamaAgent.getAgentLogText().slice(-maxChatChars);
+            await this.sendResponse(msgChat);
+            return;
+        }
+
         if (this.app.llamaAgent.isAgentInProgress() && this.app.llamaAgent.getConfirmationState() != CONFIRMATION_STATE.WAITING) {
             if (receivedMessage.toLocaleLowerCase().trim() =="/stop") {
                 this.app.llamaAgent.stopAgent()
@@ -130,19 +145,7 @@ export class TelegramBot {
                 return;
         }
 
-        if (receivedMessage.toLowerCase().startsWith(TELEGRAM_BOT_COMMANDS.SHOW_CHAT)){
-            const chatSize = receivedMessage.split(" ")[1];
-            let maxChatChars = 1000
-            if (chatSize){
-                maxChatChars = Number(chatSize);
-                if (isNaN(maxChatChars)) {
-                    maxChatChars = 1000;
-                }
-            }
-            const msgChat = this.app.configuration.getUiText(UI_TEXT_KEYS.telegramCurrentChat) + " \n" + this.app.llamaAgent.getAgentLogText().slice(-maxChatChars);
-            await this.sendResponse(msgChat);
-            return;
-        }
+        
 
         if (receivedMessage.toLowerCase().startsWith(TELEGRAM_BOT_COMMANDS.SET_AGENT)){
             const agentNumber = receivedMessage.split(" ")[1];


### PR DESCRIPTION
- [Scripts](https://github.com/ggml-org/llama.vscode/wiki/Scripts) are introduced - something like macroses for llama-vscode. Scripts are written in a simple DSL language, which supports execution of llama-vscode commands for selecting/deselecting models, agent, env, changing settings, executing terminal commands etc. The scripts also support variables, if/else statements and comments. The scripts could be used as a content of the agent commands (agent commands are shown by pressing / in the agent prompt field). The plan is in future the scripts to be used in the hooks (not yet introduced)
- The agent commands, which send prompt to the agent are now visualized with [p] preffix, while those, which execute scripts and do not send prompt are visualized with [s] preffix.
- New setting scripts_folder - the files in this folder with extension .lvs are considered as agent script commands and are shown on entering "/" in the agent prompt field. Those commands do not send prompt to the agent.
- More informative errors in case of problems with code completion.
- Telegram bot - the /chat command for showing the current chat (last xx chars) is availabe even while the agent is running.