### PR TITLE
Fix environment auto-start persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1116,7 +1116,7 @@
         "llama-vscode.env_start_last_used": {
           "type": "boolean",
           "default": false,
-          "description": "If true - starts the last used env on startup."
+          "description": "Starts the last used env when VS Code starts. In User settings, the last used env is shared across workspaces in the current VS Code profile. In Workspace settings, each workspace remembers its own env."
         },
         "llama-vscode.ask_install_llamacpp": {
           "type": "boolean",
@@ -1131,7 +1131,7 @@
         "llama-vscode.env_start_last_used_confirm": {
           "type": "boolean",
           "default": true,
-          "description": "If true, before starting the last used env, the user is asked for confirmation. Used only if env_start_last_used = true"
+          "description": "Asks for confirmation before starting the last used env. Used only when env_start_last_used is enabled. Choosing \"Yes, don't ask again\" disables confirmation at the applicable User or Workspace scope."
         },
         "llama-vscode.auto": {
           "type": "boolean",

--- a/src/application.ts
+++ b/src/application.ts
@@ -262,9 +262,14 @@ export class Application {
         this.llamaWebviewProvider.updateLlamaView();
     }
 
-    public setSelectedEnv(env: Env): void {
+    public async setSelectedEnv(env: Env, persist: boolean = true): Promise<void> {
         this.selectedEnv = env;
-        this.persistence.setValue(PERSISTENCE_KEYS.SELECTED_ENV, env);
         this.llamaWebviewProvider.updateLlamaView();
-    } 
+        if (persist) {
+            await Promise.all([
+                this.persistence.setValue(PERSISTENCE_KEYS.SELECTED_ENV, env),
+                this.persistence.setGlobalValue(PERSISTENCE_KEYS.LAST_USED_ENV, env),
+            ]);
+        }
+    }
 }

--- a/src/architect.ts
+++ b/src/architect.ts
@@ -36,27 +36,34 @@ export class Architect {
             this.app.persistence.setGlobalValue(PERSISTENCE_KEYS.EXTENSION_VERSION, currentVersion);
         }
         await this.installUpgradeLlamaCpp(isFirstStart);
-        if (this.app.configuration.env_start_last_used){
-            let lastEnv = this.app.persistence.getValue("selectedEnv")
-            if (lastEnv) {
-                if (this.app.configuration.env_start_last_used_confirm) {
-                    let [shouldSelect, dontAskAgain]  = await this.app.dialogs.showYesYesdontaskNoDialog("You are about to select the env below. If there are local models inside, they will be downloaded (if not yet done) and llama.cpp server(s) will be started. \n\n" +
-                                                                        this.app.envService.getEnvDetailsAsString(lastEnv) +
-                                                                        "\n\n Do you want to continue?"
-                                                                        );
-                    if (shouldSelect) this.app.envService.selectStartEnv(lastEnv, false);
-                    if (dontAskAgain) this.app.configuration.updateConfigValue("env_start_last_used_confirm", false);
-                } else {
-                     this.app.envService.selectStartEnv(lastEnv, false);
-                }
-
-            }
+        try {
+            await this.restoreLastUsedEnv();
+        } catch (error) {
+            console.error("Failed to restore the last used env:", error);
         }
         let lastChat = this.app.persistence.getValue(PERSISTENCE_KEYS.SELECTED_CHAT)
         if (lastChat) this.app.chatService.selectUpdateChat(lastChat)
         let lastAgent = this.app.persistence.getValue(PERSISTENCE_KEYS.SELECTED_AGENT)
         if (lastAgent) this.app.agentService.selectAgent(lastAgent)
         this.app.tools.init()
+    }
+
+    private restoreLastUsedEnv = async (): Promise<void> => {
+        if (!this.app.configuration.env_start_last_used) return;
+
+        const lastEnv = this.app.envService.getPersistedEnvForAutoStart();
+        if (!lastEnv) return;
+
+        if (this.app.configuration.env_start_last_used_confirm) {
+            const [shouldSelect, dontAskAgain] = await this.app.dialogs.showYesYesdontaskNoDialog("You are about to select the env below. If there are local models inside, they will be downloaded (if not yet done) and llama.cpp server(s) will be started. \n\n" +
+                this.app.envService.getEnvDetailsAsString(lastEnv) +
+                "\n\n Do you want to continue?"
+            );
+            if (!shouldSelect) return;
+            if (dontAskAgain) await this.app.configuration.updateEnvStartLastUsedConfirm(false);
+        }
+
+        await this.app.envService.selectStartEnv(lastEnv, false, "restoration");
     }
 
     setOnSaveDeleteFileForDb = (context: vscode.ExtensionContext) => {
@@ -78,14 +85,14 @@ export class Architect {
             this.app.configuration.updateOnEvent(event, config);
             if (this.app.configuration.isRagConfigChanged(event)){
                 this.app.llamaWebviewProvider.updateSettingsInView();
-                this.init();
+                this.indexWorspaceFiles();
             }
             if (this.app.configuration.isToolChanged(event)) this.app.tools.init();
             if (this.app.configuration.isEnvViewSettingChanged(event)) this.app.llamaWebviewProvider.updateLlamaView();
             if (this.app.configuration.isTelegramBotConfigChanged(event)){
                 if (this.app.configuration.telegram_bot_enabled) this.app.telegramBot.createBot(this.app.configuration.telegram_api_token);
                 else this.app.telegramBot.closeBot();
-            } 
+            }
             if (this.app.configuration.isCompletionsEnabledConfigChanged(event)) this.app.statusbar.updateStatusBarText();
         });
         context.subscriptions.push(configurationChangeDisp);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -295,10 +295,9 @@ export class Configuration {
         this.agents_list = this.normalizeAgents(config.get("agents_list") ?? new Array());
         this.agent_rules = String(config.get<string>("agent_rules"));
         this.agent_commands = config.get("agent_commands")??new Array();
-        this.env_start_last_used = Boolean(config.get<boolean>("env_start_last_used", true));
+        this.env_start_last_used = Boolean(config.get<boolean>("env_start_last_used", false));
         this.tools_custom = config.get("tools_custom")??new Array();
         this.context_custom = config.get("context_custom")??{};
-        this.env_start_last_used = Boolean(config.get<boolean>("env_start_last_used", true));
         this.env_start_last_used_confirm = Boolean(config.get<boolean>("env_start_last_used_confirm", true));
         this.ask_install_llamacpp = Boolean(config.get<boolean>("ask_install_llamacpp", true));
         this.ask_upgrade_llamacpp_hours = Number(config.get<number>("ask_upgrade_llamacpp_hours"));
@@ -372,7 +371,6 @@ export class Configuration {
             this.setLlamaRequestConfig();
             this.setOpenAiClient();
         }
-        if (event.affectsConfiguration("llama-vscode.env_start_last_used")) this.updateConfigValue("env_start_last_used_confirm", true);
     };
 
     isEnvViewSettingChanged = (event: vscode.ConfigurationChangeEvent) => {
@@ -505,7 +503,31 @@ export class Configuration {
         return true;
     }
 
-    updateConfigValue = async (settingName: string, value: any) => {
-        await this.config.update(settingName, value, true);
+    getEnvStartLastUsedScope = (): vscode.ConfigurationTarget => {
+        const inspected = this.config.inspect<boolean>("env_start_last_used");
+        if (inspected?.workspaceValue !== undefined) return vscode.ConfigurationTarget.Workspace;
+        if (inspected?.globalValue !== undefined) return vscode.ConfigurationTarget.Global;
+        return vscode.ConfigurationTarget.Workspace;
+    }
+
+    updateEnvStartLastUsed = async (value: boolean) => {
+        const inspected = this.config.inspect<boolean>("env_start_last_used");
+        const target = inspected?.workspaceValue !== undefined
+            ? vscode.ConfigurationTarget.Workspace
+            : vscode.ConfigurationTarget.Global;
+        await this.updateConfigValue("env_start_last_used", value, target);
+    }
+
+    updateEnvStartLastUsedConfirm = async (value: boolean) => {
+        const confirm = this.config.inspect<boolean>("env_start_last_used_confirm");
+        const target = this.getEnvStartLastUsedScope() === vscode.ConfigurationTarget.Workspace
+            || confirm?.workspaceValue !== undefined
+            ? vscode.ConfigurationTarget.Workspace
+            : vscode.ConfigurationTarget.Global;
+        await this.updateConfigValue("env_start_last_used_confirm", value, target);
+    }
+
+    updateConfigValue = async (settingName: string, value: any, target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global) => {
+        await this.config.update(settingName, value, target);
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -309,6 +309,7 @@ export const PERSISTENCE_KEYS = {
   SELECTED_CHAT: 'selectedChat' as const,
   SELECTED_AGENT: 'selectedAgent' as const,
   SELECTED_ENV: 'selectedEnv' as const,
+  LAST_USED_ENV: 'lastUsedEnv' as const,
   EXTENSION_VERSION: 'extensionVersion' as const,
 } as const;
 

--- a/src/dsl-commands.ts
+++ b/src/dsl-commands.ts
@@ -127,7 +127,7 @@ export class DslCommands {
             .concat((PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.ENVS) as Env[]))
         const env = allEnvs.find((env) => env.name === envName);
         if (env) {
-            this.app.envService.selectStartEnv(env, true)
+            await this.app.envService.selectStartEnv(env, true)
             result = `Env ${envName} is selected.`
         } else {
             result = `Env ${envName} is not found.`
@@ -319,7 +319,8 @@ export class DslCommands {
         settingValue = this.stripArgumentValue(settingValue)
             
         const value = this.getPropertyType(this.app.configuration, settingName as keyof typeof this.app.configuration);
-        if (typeof value == "boolean") await this.app.configuration.updateConfigValue(settingName, settingValue.toLowerCase() == "true")
+        if (settingName == "env_start_last_used") await this.app.configuration.updateEnvStartLastUsed(settingValue.toLowerCase() == "true")
+        else if (typeof value == "boolean") await this.app.configuration.updateConfigValue(settingName, settingValue.toLowerCase() == "true")
         else if (typeof value == "number") await this.app.configuration.updateConfigValue(settingName, Number(settingValue))
         else await this.app.configuration.updateConfigValue(settingName, settingValue)
         

--- a/src/llama-webview-provider.ts
+++ b/src/llama-webview-provider.ts
@@ -443,7 +443,7 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
     }
     
     toggleAutoStartEnv = async (message: any, webviewView: vscode.WebviewView) => {
-        this.app.configuration.updateConfigValue("env_start_last_used", message.enabled)
+        await this.app.configuration.updateEnvStartLastUsed(message.enabled)
     }
         
     getVscodeSetting = async (message: any, webviewView: vscode.WebviewView) => {
@@ -783,4 +783,4 @@ export class LlamaWebviewProvider implements vscode.WebviewViewProvider {
         </body>
         </html>`;
     }
-} 
+}

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -57,8 +57,8 @@ export class Persistence {
         return this.context.workspaceState.get<Chat[]>(this.uniquePrefix + this.chatsName);
     }
 
-    deleteValue = (key: string) => {
-        this.context.workspaceState.update(this.uniquePrefix + key, undefined);
+    deleteValue = async (key: string) => {
+        await this.context.workspaceState.update(this.uniquePrefix + key, undefined);
     }
 
     setGlobalValue = async (key: string, value: any) => {
@@ -69,7 +69,7 @@ export class Persistence {
         return this.context.globalState.get(this.uniquePrefix + key);
     }
 
-    deleteGlobalValue = (key: string) => {
-        this.context.globalState.update(this.uniquePrefix + key, undefined);
+    deleteGlobalValue = async (key: string) => {
+        await this.context.globalState.update(this.uniquePrefix + key, undefined);
     }
 }

--- a/src/services/env-service.ts
+++ b/src/services/env-service.ts
@@ -9,11 +9,30 @@ import * as path from "path";
 import { PREDEFINED_LISTS } from "../lists";
 import { ModelType, UI_TEXT_KEYS, PERSISTENCE_KEYS, SETTING_NAME_FOR_LIST, PREDEFINED_LISTS_KEYS } from "../constants";
 
+type EnvSelectionMode = "fresh" | "restoration";
+
 export class EnvService {
     private app: Application;
 
     constructor(app: Application) {
         this.app = app;
+    }
+
+    private getValidPersistedEnv(value: unknown): Env | undefined {
+        if (!value || typeof value !== "object") return undefined;
+        const env = value as Env;
+        return typeof env.name === "string" && env.name.trim() !== "" ? env : undefined;
+    }
+
+    getWorkspaceSelectedEnv(): Env | undefined {
+        return this.getValidPersistedEnv(this.app.persistence.getValue(PERSISTENCE_KEYS.SELECTED_ENV));
+    }
+
+    getPersistedEnvForAutoStart(): Env | undefined {
+        const value = this.app.configuration.getEnvStartLastUsedScope() === vscode.ConfigurationTarget.Workspace
+            ? this.app.persistence.getValue(PERSISTENCE_KEYS.SELECTED_ENV)
+            : this.app.persistence.getGlobalValue(PERSISTENCE_KEYS.LAST_USED_ENV);
+        return this.getValidPersistedEnv(value);
     }
 
     getActions(): vscode.QuickPickItem[] {
@@ -80,28 +99,29 @@ export class EnvService {
         let allEnvs = envsList.concat(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.ENVS) as Env[]);
         let envsItems: QuickPickItem[] = this.getStandardQpList(envsList, "");
         envsItems = envsItems.concat(this.getStandardQpList(PREDEFINED_LISTS.get(PREDEFINED_LISTS_KEYS.ENVS) as Env[], "(predefined) ", envsList.length));
-        let lastUsedEnv = this.app.persistence.getValue(PERSISTENCE_KEYS.SELECTED_ENV) as Env;
-        if (lastUsedEnv && lastUsedEnv.name.trim() !== "") {
+        let lastUsedEnv = this.getWorkspaceSelectedEnv();
+        if (lastUsedEnv) {
             envsItems.push({ label: (envsItems.length + 1) + ". Last used env", description: lastUsedEnv.name });
         }
         const envItem = await vscode.window.showQuickPick(envsItems);
         if (envItem) {
             let selectedEnv: Env;
             if (envItem.label.includes("Last used env")) {
+                if (!lastUsedEnv) return undefined;
                 selectedEnv = lastUsedEnv;
             } else {
                 const index = parseInt(envItem.label.split(". ")[0], 10) - 1;
                 selectedEnv = allEnvs[index];
             }
             if (selectedEnv) {
-                await this.selectStartEnv(selectedEnv, confirm);
+                await this.selectStartEnv(selectedEnv, confirm, "fresh");
                 return selectedEnv;
             }
         }
         return undefined;
     }
 
-    async selectStartEnv(env: Env, confirm: boolean = false): Promise<void> {
+    async selectStartEnv(env: Env, confirm: boolean = false, selectionMode: EnvSelectionMode = "fresh"): Promise<void> {
         // Get current state for inheritance
         const currentComplModel = this.app.getComplModel();
         const currentChatModel = this.app.getChatModel();
@@ -139,6 +159,11 @@ export class EnvService {
         }
 
         if (shouldSelect && env) {
+            if (selectionMode === "restoration") {
+                // Keep the restored environment visible even if one of its model startups fails.
+                await this.app.setSelectedEnv(env, false);
+            }
+
             // Set completion model (inherit if not specified)
             const complModel = env.completion ?? currentComplModel;
             this.app.setSelectedModel(ModelType.Completion, complModel);
@@ -192,17 +217,16 @@ export class EnvService {
             if (env.ragEnabled !== undefined) {
                 this.app.configuration.updateConfigValue("rag_enabled", env.ragEnabled);
             }
-            if (env.envStartLastUsed !== undefined) {
-                this.app.configuration.updateConfigValue("env_start_last_used", env.envStartLastUsed);
+            if (env.envStartLastUsed !== undefined && env.envStartLastUsed !== this.app.configuration.env_start_last_used) {
+                await this.app.configuration.updateEnvStartLastUsed(env.envStartLastUsed);
             }
             if (env.complEnabled !== undefined) {
                 this.app.configuration.updateConfigValue("enabled", env.complEnabled);
             }
 
-            // Set selected env
-            this.app.setSelectedEnv(env);
-
-            this.app.llamaWebviewProvider.updateLlamaView();
+            if (selectionMode === "fresh") {
+                await this.app.setSelectedEnv(env);
+            }
         }
     }
 
@@ -302,8 +326,12 @@ export class EnvService {
         await this.app.llamaServer.killToolsCmd();
         this.app.setSelectedModel(ModelType.Tools, { name: "", localStartCommand: "" });
         await this.app.agentService.deselectAgent();
-        this.app.setSelectedEnv({ name: "" });
-        this.app.llamaWebviewProvider.updateLlamaView();
+        if (this.app.configuration.getEnvStartLastUsedScope() === vscode.ConfigurationTarget.Workspace) {
+            await this.app.persistence.deleteValue(PERSISTENCE_KEYS.SELECTED_ENV);
+        } else {
+            await this.app.persistence.deleteGlobalValue(PERSISTENCE_KEYS.LAST_USED_ENV);
+        }
+        await this.app.setSelectedEnv({ name: "" }, false);
         vscode.window.showInformationMessage("Env, models and agent are deselected.")
     }
 

--- a/src/test/suite/env-start-last-used.test.ts
+++ b/src/test/suite/env-start-last-used.test.ts
@@ -1,0 +1,210 @@
+/// <reference types="mocha" />
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { suite, test } from 'mocha';
+import { Application } from '../../application';
+import { Architect } from '../../architect';
+import { Configuration } from '../../configuration';
+import { PERSISTENCE_KEYS } from '../../constants';
+import { EnvService } from '../../services/env-service';
+import { Env } from '../../types';
+
+suite('Environment Auto-Start Test Suite', () => {
+    test('changing auto-start does not reset confirmation', () => {
+        const configuration = new Configuration();
+        let writes = 0;
+        configuration.updateConfigValue = async () => {
+            writes += 1;
+        };
+
+        configuration.updateOnEvent({
+            affectsConfiguration: (section: string) => section === 'llama-vscode.env_start_last_used',
+        } as vscode.ConfigurationChangeEvent, vscode.workspace.getConfiguration('llama-vscode'));
+
+        assert.strictEqual(writes, 0);
+    });
+
+    test('uses the effective User or Workspace configuration target', async () => {
+        const configuration = new Configuration();
+        const workspaceWrites: Array<{ setting: string; target: vscode.ConfigurationTarget | boolean | null | undefined }> = [];
+
+        configuration.config = {
+            inspect: (section: string) => section === 'env_start_last_used'
+                ? { globalValue: true, workspaceValue: false }
+                : { globalValue: true },
+            update: async (setting: string, _value: unknown, target?: vscode.ConfigurationTarget | boolean | null) => {
+                workspaceWrites.push({ setting, target });
+            },
+        } as unknown as vscode.WorkspaceConfiguration;
+
+        assert.strictEqual(configuration.getEnvStartLastUsedScope(), vscode.ConfigurationTarget.Workspace);
+        await configuration.updateEnvStartLastUsed(true);
+        await configuration.updateEnvStartLastUsedConfirm(false);
+        assert.deepStrictEqual(workspaceWrites, [
+            { setting: 'env_start_last_used', target: vscode.ConfigurationTarget.Workspace },
+            { setting: 'env_start_last_used_confirm', target: vscode.ConfigurationTarget.Workspace },
+        ]);
+
+        const globalWrites: Array<{ setting: string; target: vscode.ConfigurationTarget | boolean | null | undefined }> = [];
+        configuration.config = {
+            inspect: () => ({ globalValue: false }),
+            update: async (setting: string, _value: unknown, target?: vscode.ConfigurationTarget | boolean | null) => {
+                globalWrites.push({ setting, target });
+            },
+        } as unknown as vscode.WorkspaceConfiguration;
+
+        assert.strictEqual(configuration.getEnvStartLastUsedScope(), vscode.ConfigurationTarget.Global);
+        await configuration.updateEnvStartLastUsed(true);
+        await configuration.updateEnvStartLastUsedConfirm(false);
+        assert.deepStrictEqual(globalWrites, [
+            { setting: 'env_start_last_used', target: vscode.ConfigurationTarget.Global },
+            { setting: 'env_start_last_used_confirm', target: vscode.ConfigurationTarget.Global },
+        ]);
+    });
+
+    test('fresh selection writes both histories while restoration writes neither', async () => {
+        const writes: Array<{ store: string; key: string; value: unknown }> = [];
+        const app = Object.create(Application.prototype) as Application;
+        app.persistence = {
+            setValue: async (key: string, value: unknown) => {
+                writes.push({ store: 'workspace', key, value });
+            },
+            setGlobalValue: async (key: string, value: unknown) => {
+                writes.push({ store: 'global', key, value });
+            },
+        } as unknown as Application['persistence'];
+        app.llamaWebviewProvider = {
+            updateLlamaView: () => undefined,
+        } as unknown as Application['llamaWebviewProvider'];
+        const fresh: Env = { name: 'fresh' };
+
+        await app.setSelectedEnv(fresh);
+        assert.deepStrictEqual(writes, [
+            { store: 'workspace', key: PERSISTENCE_KEYS.SELECTED_ENV, value: fresh },
+            { store: 'global', key: PERSISTENCE_KEYS.LAST_USED_ENV, value: fresh },
+        ]);
+
+        await app.setSelectedEnv({ name: 'restored' }, false);
+        assert.strictEqual(writes.length, 2);
+    });
+
+    test('reads only the history selected by configuration scope', () => {
+        const workspaceEnv: Env = { name: 'workspace' };
+        const globalEnv: Env = { name: 'global' };
+
+        for (const [target, expected] of [
+            [vscode.ConfigurationTarget.Workspace, workspaceEnv],
+            [vscode.ConfigurationTarget.Global, globalEnv],
+        ] as const) {
+            const app = {
+                configuration: {
+                    getEnvStartLastUsedScope: () => target,
+                },
+                persistence: {
+                    getValue: () => workspaceEnv,
+                    getGlobalValue: () => globalEnv,
+                },
+            } as unknown as Application;
+
+            assert.strictEqual(new EnvService(app).getPersistedEnvForAutoStart(), expected);
+        }
+
+        const app = {
+            configuration: {
+                getEnvStartLastUsedScope: () => vscode.ConfigurationTarget.Workspace,
+            },
+            persistence: {
+                getValue: () => ({ name: '' }),
+            },
+        } as unknown as Application;
+        assert.strictEqual(new EnvService(app).getPersistedEnvForAutoStart(), undefined);
+    });
+
+    test('keeps restoration visible without remembering a failed fresh selection', async () => {
+        const events: string[] = [];
+        const restoredEnv = { name: 'remembered', completion: { name: 'completion' } } as Env;
+        const app = {
+            getComplModel: () => ({ name: '' }),
+            getChatModel: () => ({ name: '' }),
+            getEmbeddingsModel: () => ({ name: '' }),
+            getToolsModel: () => ({ name: '' }),
+            getAgent: () => ({ name: '', systemInstruction: [] }),
+            configuration: {
+                rag_enabled: false,
+                env_start_last_used: true,
+                enabled: true,
+            },
+            llamaServer: {
+                killFimCmd: () => undefined,
+                killChatCmd: () => undefined,
+                killEmbeddingsCmd: () => undefined,
+                killToolsCmd: () => undefined,
+            },
+            setSelectedEnv: async (env: Env, persist: boolean) => {
+                events.push(`selected:${env.name}:${persist}`);
+            },
+            setSelectedModel: () => undefined,
+            modelService: {
+                addApiKey: async () => {
+                    events.push('startup');
+                    throw new Error('model startup failed');
+                },
+            },
+        } as unknown as Application;
+
+        await assert.rejects(
+            new EnvService(app).selectStartEnv(restoredEnv, false, 'restoration'),
+            /model startup failed/
+        );
+        assert.deepStrictEqual(events, ['selected:remembered:false', 'startup']);
+
+        events.length = 0;
+        await assert.rejects(
+            new EnvService(app).selectStartEnv(restoredEnv, false, 'fresh'),
+            /model startup failed/
+        );
+        assert.deepStrictEqual(events, ['startup']);
+    });
+
+    test("don't ask again is saved before startup and suppresses the next prompt", async () => {
+        const events: string[] = [];
+        const configuration = {
+            env_start_last_used: true,
+            env_start_last_used_confirm: true,
+            updateEnvStartLastUsedConfirm: async (value: boolean) => {
+                events.push(`confirmation:${value}`);
+                configuration.env_start_last_used_confirm = value;
+            },
+        };
+        const app = {
+            configuration,
+            dialogs: {
+                showYesYesdontaskNoDialog: async () => {
+                    events.push('dialog');
+                    return [true, true] as [boolean, boolean];
+                },
+            },
+            envService: {
+                getPersistedEnvForAutoStart: () => ({ name: 'remembered' }),
+                getEnvDetailsAsString: () => 'details',
+                selectStartEnv: async (_env: Env, _confirm: boolean, mode: string) => {
+                    events.push(`start:${mode}`);
+                    return true;
+                },
+            },
+        } as unknown as Application;
+        const architect = new Architect(app) as unknown as {
+            restoreLastUsedEnv: () => Promise<void>;
+        };
+
+        await architect.restoreLastUsedEnv();
+        await architect.restoreLastUsedEnv();
+
+        assert.deepStrictEqual(events, [
+            'dialog',
+            'confirmation:false',
+            'start:restoration',
+            'start:restoration',
+        ]);
+    });
+});


### PR DESCRIPTION
The confirmation was being reset whenever env_start_last_used changed, including when selecting an env that had envStartLastUsed enabled. “Yes, don’t ask again” now updates the correct setting and is no longer reset automatically.

The last used env now follows the scope of env_start_last_used: User settings use a profile-wide env across workspaces, while Workspace settings keep a separate env for each workspace. Startup restoration does not overwrite.
Also fixed a case where changing a RAG setting could rerun the full initialization and trigger env restoration again.


Resolves #203 

AI usage disclosure: YES, GPT-5.6 as a coding assistant + wrote the test