### PR TITLE
feat: add OrcaRouter as an OpenAI-compatible provider preset

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -361,10 +361,12 @@ export const TELEGRAM_BOT_COMMANDS = {
 
 export enum OpenAiProvidersKeys {
   OpenRouter = 'OpenRouter...',
+  OrcaRouter = 'OrcaRouter...',
   Custom = 'Custom...'
 }
 export const OPENAI_COMP_PROVIDERS = {
   [OpenAiProvidersKeys.OpenRouter]: "https://openrouter.ai/api",
+  [OpenAiProvidersKeys.OrcaRouter]: "https://api.orcarouter.ai",
   [OpenAiProvidersKeys.Custom]: ""
 } as const
 


### PR DESCRIPTION
## Summary

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) preset to the "Add model from OpenAI-compatible provider" flow, mirroring how this repo already treats OpenRouter-style aggregators. Selecting it populates the endpoint with `https://api.orcarouter.ai` (the model picker then lists OrcaRouter's catalog via `/v1/models` and sends requests to `/v1/chat/completions`). Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/constants.ts`: adds `OrcaRouter` to the `OpenAiProvidersKeys` enum and registers `https://api.orcarouter.ai` in `OPENAI_COMP_PROVIDERS`. The existing "OpenAI-compatible provider" quick pick now shows OrcaRouter as a selectable preset, so users can add an OrcaRouter-backed completion / chat / embeddings / tools model without typing a custom endpoint.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In the model list, choose "Add ... model from OpenAI-compatible provider" and pick OrcaRouter.
3. Enter the API key when prompted (the flow saves it for that endpoint). Pick a model from the catalog, e.g. `deepseek/deepseek-chat` or `orcarouter/auto`.

## Validation

- `npx tsc -p ./ --noEmit` -> clean (exit 0).
- Live API with a real key against the exact endpoint this PR registers:
  - `GET https://api.orcarouter.ai/v1/models` -> 200, 189 models listed (this is what the model picker fetches)
  - `POST https://api.orcarouter.ai/v1/chat/completions` -> 200 with expected reply
  - invalid key -> 401 (fails loud, no silent fallback)

The change is limited to adding one provider preset; no existing provider behavior, dependencies, or package files are touched.
