### PR TITLE
Tool edit_file improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1193,6 +1193,11 @@
           "default": false,
           "description": "Works only for llama.cpp servers - enables health check for tools model"
         },
+        "llama-vscode.only_one_local_model": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, only one local model (among completion, chat and tools) is allowed to run. On starting a local model, the other local models are automatically stopped (deselected)."
+        },
         "llama-vscode.n_prefix": {
           "default": 256,
           "type": "number",

--- a/resources/help.md
+++ b/resources/help.md
@@ -306,12 +306,19 @@ Settings:
 <img width="580" height="779" alt="image" src="https://github.com/user-attachments/assets/bb29e0c8-85b4-4e7a-a3d9-f2d9a1679d3d" />
 
 
+## Version 0.0.61 is released (17.08.2026)
+### What is new
+- Improve edit text with AI and edit multiple files with AI - adding context from .md files is now possible
+- Fix loosing agent context files on hiding and showing agent view
+- Agent Reminders added - for example periodically reminds the agent about the correct format of the edit_file tool input parameter (setting reminder_edit_file_frequency). 
+- Default models introduced - if a model is not selected, the default one (if any) is selected automatically
+
 ## Version 0.0.60 is released (15.08.2026)
 ### What is new
 - Fix environment auto-start persistence
 - Add OrcaRouter as an OpenAI-compatible provider (enables adding models in the same way as from OpenRounter - from the menu)
 - Telegram bot new command "//" - shows all agent commands
-- Telegram bot - the agent commands are now requested with simeple /<command>, not with //<command> anymore, to facilitate the execution of the command inside telegram (just tap on it from the list if it contains only acceptable chars for telegram command)
+- Telegram bot - the agent commands are now requested with simple /<command>, not with //<command> anymore, to facilitate the execution of the command inside telegram (just tap on it from the list if it contains only acceptable chars for telegram command)
 - Script files (suffix .lvs) from folder of the setting scripts_folder are availabe as script commands in the agent.
 
 ## Version 0.0.59 is released (07.08.2026)
@@ -1355,7 +1362,8 @@ Here are the commands (messages, which start with "/"), which the bot can execut
 - /chat n - gets the last n  characters of the current chat. If n is not specified, the last 1000 characters are returned
 - /newchat, /new - stops the current chat and starts a new chat
 - /setlang xx - sets the language, which is used by the bot: bg - Bulgarian (Български), cn - Chinese (中文), en - English, fr - French (Français), de - German (Deutsch), ru - Russian (Русский), es - Spanish (Español)
-- / - shows available commands
+- / - shows available telegram bot commands
+- // - shows the available agent commands
 - /help - shows help information for using the bot
 
 ### Settings:  

--- a/resources/help.md
+++ b/resources/help.md
@@ -272,6 +272,9 @@ Deselect env from llama-vscode ui or from llama-vscode menu, "Deselect/stop env.
 
 There is a page in llama-vscode UI with the current environment details. From there it is possible to change the current environment and also save it (i.e. create a new env)
 
+### Settings
+only_one_local_model - if true - on selecting a local model, the other selected local models are deselected/stopped. This is valid for completion, chat and tools models. Embeddings models are small and therefore excuded from the group. By default it is false.
+
 <img width="540" height="996" alt="image" src="https://github.com/user-attachments/assets/b1a78d7a-8602-451a-b304-fc967fb66696" />
 
 ## Generate a commit message  
@@ -306,6 +309,13 @@ Settings:
 <img width="580" height="779" alt="image" src="https://github.com/user-attachments/assets/bb29e0c8-85b4-4e7a-a3d9-f2d9a1679d3d" />
 
 
+## Version 0.0.62 is released (18.08.2026)
+### What is new
+- Tool edit_file is reimplemented - now it uses simple search/replace and requires the file to be read after the latest modification
+- Property only_one_local_model added for ease of use with local models. If true - on selecting a local model, the other selected local models are deselected/stopped. This is valid for completion, chat and tools models. Embeddings models are small and therefore excuded from the group. By default it is false.
+
+
+
 ## Version 0.0.61 is released (17.08.2026)
 ### What is new
 - Improve edit text with AI and edit multiple files with AI - adding context from .md files is now possible
@@ -313,13 +323,15 @@ Settings:
 - Agent Reminders added - for example periodically reminds the agent about the correct format of the edit_file tool input parameter (setting reminder_edit_file_frequency). 
 - Default models introduced - if a model is not selected, the default one (if any) is selected automatically
 
+
 ## Version 0.0.60 is released (15.08.2026)
 ### What is new
 - Fix environment auto-start persistence
 - Add OrcaRouter as an OpenAI-compatible provider (enables adding models in the same way as from OpenRounter - from the menu)
 - Telegram bot new command "//" - shows all agent commands
-- Telegram bot - the agent commands are now requested with simple /<command>, not with //<command> anymore, to facilitate the execution of the command inside telegram (just tap on it from the list if it contains only acceptable chars for telegram command)
+- Telegram bot - the agent commands are now requested with simeple /<command>, not with //<command> anymore, to facilitate the execution of the command inside telegram (just tap on it from the list if it contains only acceptable chars for telegram command)
 - Script files (suffix .lvs) from folder of the setting scripts_folder are availabe as script commands in the agent.
+
 
 ## Version 0.0.59 is released (07.08.2026)
 ### What is new
@@ -390,7 +402,7 @@ Settings:
 
 
 ### Version 0.0.50 is released (26.06.2026)
-## What is new
+### What is new
 
 * Option for using standard shell script for llama.cpp installation (brew / winget also available)
 * Use "llama server" instead of llama-server to start a local server
@@ -398,7 +410,7 @@ Settings:
 
 
 ## Version 0.0.49 is released (26.06.2026)
-## What is new
+### What is new
 
 * User dialogs are now two types - popup dialogs (for short texts) and dialogs in editor (for long texts)
 * Setting popup_max_chars (default 160) determines what is the max length of short texts (popup dialogs used for them)
@@ -407,7 +419,7 @@ Settings:
 
 
 ## Version 0.0.48 is released (01.06.2026)
-## What is new
+### What is new
 
 Thanks to @danielrobbins we have the following improvements:
 
@@ -434,7 +446,7 @@ This fixes the context size shown in the VS Code model UI so shared-context llam
 
 
 ## Version 0.0.47 is released (04.05.2026)
-## What is new
+### What is new
 
 - Multiline field for Edit with AI  
 - Qwen3.5 models added as predefined (2B, 4B, 9B) - good for tools and chat  
@@ -442,7 +454,7 @@ This fixes the context size shown in the VS Code model UI so shared-context llam
 
 
 ## Version 0.0.46 is released (29.04.2026)
-## What is new
+### What is new
 
 llama.vscode could provide models for VS Code Copilot now:
 1. Start tools model from llama-vscode (local or external)  
@@ -455,7 +467,7 @@ Not needed tools from Copilot could be unchecked to reduce contex size if local 
 
 
 ## Version 0.0.45 is released (04.03.2026)
-## What is new
+### What is new
 
 - Configurable debounce for inline completion requests - setting debounce_ms. 
 llama-vscode will wait debounce_ms after a keystroke before sending a request to the LLM for inline code completion. If in the meantime there is another keystroke, the request for the previous keystroke is cancelled. Useful on low end hardware to avoid triggering code completion on every keystroke.
@@ -464,7 +476,7 @@ llama-vscode will wait debounce_ms after a keystroke before sending a request to
 
 
 ## Version 0.0.44 is released (03.03.2026)
-## What is new
+### What is new
 
 - Subagents implemented (with tool delegate_task) - now each agent, which has "Available as Subagent" checked could be used as a subagent
 

--- a/src/agent-reminder.ts
+++ b/src/agent-reminder.ts
@@ -52,7 +52,7 @@ export class AgentReminder {
     }
 
     remindEditFile = (iteration: number ) => {
-        return `If you use edit_file tool, the input parameter should has the following ${this.app.prompts.EDIT_TOOL_BASIC_STRUCTURE}} `
+        return `${this.app.prompts.EDIT_FILE_REMINDER}`
     }
 
     initReminders = () => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -56,6 +56,7 @@ export class Configuration {
     health_check_chat_enabled = false;
     health_check_embs_enabled = false;
     health_check_tools_enabled = false;
+    only_one_local_model = false;
 
 
     // experimental - avoid using
@@ -260,6 +261,7 @@ export class Configuration {
         this.tool_update_todo_list_enabled = Boolean(config.get<boolean>("tool_update_todo_list_enabled"));
         this.tool_delegate_task_enabled = Boolean(config.get<boolean>("tool_delegate_task_enabled"));
         this.tool_llama_vscode_help_enabled = Boolean(config.get<boolean>("tool_llama_vscode_help_enabled"));
+        this.only_one_local_model = Boolean(config.get<boolean>("only_one_local_model"));
         this.tool_custom_tool_description = String(config.get<string>("tool_custom_tool_description"));
         this.tool_custom_tool_source = String(config.get<string>("tool_custom_tool_source"));
         this.tool_custom_eval_tool_enabled = Boolean(config.get<boolean>("tool_custom_eval_tool_enabled"));

--- a/src/llama-agent.ts
+++ b/src/llama-agent.ts
@@ -5,7 +5,7 @@ import { Utils } from "./utils"
 import { Chat } from "./types"
 import { Plugin } from './plugin';
 import * as fs from 'fs';
-import { AGENT_COMMAND, PREDEFINED_LISTS_KEYS, SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
+import { AGENT_COMMAND, ModelType, PERSISTENCE_KEYS, PREDEFINED_LISTS_KEYS, SUPPORTED_IMG_FILE_EXTS, UI_TEXT_KEYS } from "./constants";
 import path from "path";
 import { DEFAULT_CONTEXT_SAFETY_MARGIN_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS, resolveBoundedMaxOutputTokens } from './language-model-token-limits';
 import { PREDEFINED_LISTS } from "./lists";
@@ -377,7 +377,9 @@ export class LlamaAgent {
             }
             
             this.setAgentState("AI is working...", true)
-            
+            if (!this.app.isToolsModelSelected() && !this.app.configuration.endpoint_tools){
+                await this.app.modelService.selectDefaultModel(ModelType.Tools, PERSISTENCE_KEYS.DEFAULT_TOOLS_MODEL);
+            }
             if (!this.app.isToolsModelSelected() && !this.app.configuration.endpoint_tools) {
                 vscode.window.showErrorMessage("Error: Tools model is not selected! Select tools model (or env with tools model) or set and endpoint in setting endpoint_tools if you want to to use Llama Agent View.")
                 this.setAgentState("AI is stopped", false)

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -149,61 +149,131 @@ Task:
 Expected result: 
 {expected_result}
 `
-EDIT_TOOL_BASIC_STRUCTURE = `Basic Format Structure:
-\`\`\`diff
-filename.py
-<<<<<<< SEARCH  
-// original text lines that should be found and replaced (with all spaces, tabs, etc.. EXACT MATCH is needed)  
-=======  
-// new text lines that will replace the original content  
->>>>>>> REPLACE  
-\`\`\``
+EDIT_FILE_REMINDER = `[REMINDER] When using edit_file:
 
-TOOL_APPLY_EDITS = `
-Edits/creates file. Use this tool only if file content or at least  section of the file is already read and there is a sufficient context. Provide here exactly one file with user instruction to make one change to it using a diff-fenced format. 
+1. "search" MUST be a VERBATIM, exact copy (character-for-character, spaces, tabs, newlines) of the text from the current file. NO approximations.
+2. The "search" block MUST appear exactly ONCE in the file (unless replace_all=true). Include 3-5 surrounding lines to guarantee uniqueness.
+3. If an edit fails, RE-READ the file immediately and retry with a more specific search block.`
 
-File is presented with its relative path followed by code fence markers and the complete file content:
+EDIT_FILE_DESC = `
+Tool: edit_file
 
-## How to make Edits (diff-fenced format):
-When making changes, you MUST use the SEARCH/REPLACE block format for the input parameter as follows:
+Purpose:
+Performs a precise, surgical edit to an existing file OR creates a new file. The tool uses exact string matching to ensure deterministic, safe modifications.
 
-1. ${this.EDIT_TOOL_BASIC_STRUCTURE}
-  
-2. Format Rules: 
-- The first line must be a code fence opening marker (\`\`\`diff)  
-- The second line must contain ONLY the file path, exactly as shown to you  
-- The SEARCH block must contain the EXACT lines with correct number of spaces or tabs before and after the text of each line, the lines should be in the same order. Never skip or shorten peaces of the content to be replaced!
-- The REPLACE block contains the new content  
-- End with a code fence closing marker (\`\`\`)  
-- Include enough context in the SEARCH block to uniquely identify the section to change  
-- Keep SEARCH/REPLACE blocks concise - break large changes into multiple calls to the tool   
-  
-3. **Creating New Files**: Use an empty SEARCH section:  
+Parameters:
+- file_path (string, Required): Absolute path to the file. Always use absolute paths to avoid ambiguity.
+- search (string, Conditional): The exact text to find and replace. Must be non-empty for edits. For file creation, set to an empty string ("").
+- replace (string, Required): The new content to insert. Can be an empty string ("") to delete the search block.
+- replace_all (boolean, Optional, default: false): If true, replaces all occurrences of search. If false, search must appear exactly once.
 
-\`\`\`diff
-new_file.py
-<<<<<<< SEARCH  
-=======  
-# New file content goes here  
-def new_function():  
-    return "Hello World"  
->>>>>>> REPLACE
-\`\`\` 
-4. **Moving Content**: Use two calls to the tool:  1. One to delete content from its original location (empty REPLACE section). 2. One to add it to the new location (empty SEARCH section)  
+Mode 1: Editing an Existing File (Primary Use)
+Use this mode when modifying a file that already exists on disk.
 
-5. **Multiple Edits**: Use separate calls to the tool for each edit.
+Prerequisites:
+1. The file must have been read earlier in this conversation (via Read or cat).
+2. The file must not have been modified externally since you last read it (staleness check).
 
-## Important Guidelines  
-  
+Rules for search:
+- Must be an exact, verbatim copy of the text you want to replace, character for character.
+- Include 3 to 5 lines of surrounding context to guarantee uniqueness and help the tool locate the correct block.
+- Preserve indentation (spaces/tabs), newlines (\n), and case exactly as they appear in the file.
+- NEVER shorten, summarize, or "approximate" the search block. A single mismatched character will cause the edit to fail.
+
+Validity checks for editing:
+- If search appears 0 times -> FAIL. Error: "Search string not found." Re-read the file and correct the block.
+- If search appears more than once and replace_all is false (default) -> FAIL. Error: "Found X matches. Provide more context or set replace_all=true."
+- If search appears exactly once -> SUCCESS. Perform the replacement.
+- If search appears more than once and replace_all is true -> SUCCESS. Replace all occurrences. Use this option sparingly and with caution.
+
+Mode 2: Creating a New File (Fallback Only)
+Use this mode only when the file does not exist yet.
+
+Rules:
+- file_path must point to a location that does not currently exist on disk.
+- search MUST be an empty string ("").
+- replace must contain the complete content for the new file.
+
+Validity checks for creation:
+- If file already exists and search is "" -> FAIL. Error: "File already exists. Use edit mode (non-empty search) to modify it."
+- If file does not exist and search is "" -> SUCCESS. Create the new file with the content from replace.
+- If file does not exist and search is non-empty -> FAIL. Error: "Cannot edit a non-existent file. To create a file, set search to ""."
+
+Examples (plain text):
+
+Example 1: Replace a function definition (existing file)
+file_path = "/home/user/src/app.py"
+search = "def calculate():\n    return 42\n"
+replace = "def calculate():\n    return 100\n"
+replace_all = false
+
+Example 2: Delete a line (set replace to empty string)
+file_path = "/home/user/config.json"
+search = "\"debug\": true,\n"
+replace = ""
+replace_all = false
+
+Example 3: Create a new file
+file_path = "/home/user/src/new_module.py"
+search = ""
+replace = "import os\n\ndef main():\n    print('Hello')\n"
+
+Critical Guidelines for the Agent:
+1. Always use absolute paths. Never rely on relative paths or the current working directory.
+2. Read before editing. Always read the file first to obtain the exact current content and to satisfy the staleness check.
+3. If an edit fails, immediately re-read the file (using Read or cat) and retry with a more specific search block. The file may have changed externally.
+4. Make small, focused edits. Break large changes into multiple small edit_file calls. This reduces token usage, makes failures easier to debug, and minimises risk.
+5. Never ignore whitespace. The match is literal. Copy indentation and line endings exactly from the current file.
+6. Deleting content: To remove text, set replace to an empty string (""). This deletes the search block entirely.
+7. Do not rewrite entire files unless absolutely necessary (for example, the file is very small and a complete restructure is required). For existing files, prefer surgical edits.
+
+Failure Responses and Agent Recovery Actions:
+- "Search string not found." -> Re-read the file (the content may have changed). Adjust search to match exactly.
+- "Found X matches. Provide more context or set replace_all=true." -> Add more surrounding lines to search to make it unique, or use replace_all=true if appropriate.
+- "File already exists. Use edit mode." -> You tried to create a file that exists. Provide a non-empty search block and edit it instead.
+- "Cannot edit a non-existent file." -> You tried to edit a file that doesn't exist. Set search to "" to create it.
+- "File has been modified since last read." -> Re-read the file to refresh your context, then attempt the edit again (this prevents overwriting external changes).
+
+Summary:
+- Editing: search = exact block to replace, replace = new content, replace_all = false by default.
+- Creating: search = "", replace = full file content.
+- Deleting: search = text to remove, replace = "".
+- Always provide absolute file_path, always read the file first, and always make small, focused changes.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Edits/creates file. Use this tool only if file content or at least section of the file is already read and there is a sufficient context. 
+
+## How to make Edits:
+Provide the file_path, search (with not empty value) and replace (optionally replace_all).
+
+- The search must contain the EXACT lines with correct number of spaces or tabs before and after the text of each line, the lines should be in the same order. Never skip or shorten peaces of the content to be replaced! search block should be found only once in the file, otherwise the edit will fail (except when replace_all is true).
+- The replace contains the new content  
+- Include enough context in the search to uniquely identify the section to change  
+- Keep search/replace blocks concise - break large changes into multiple calls to the tool   
+
+
+## How to create new file
+Provide the file_path, empty string for search and the file content in the replace.
+
+## Important Guidelines    
 1. Always include the EXACT file path as shown in the context  
-2. Make sure the SEARCH block starts with <<<<<<< SEARCH and EXACTLY matches the existing content  
 3. Break large changes into multiple smaller, focused calls to the tool  
 4. Only edit files that are already read  
-5. Explain your changes before presenting the SEARCH/REPLACE blocks  
- 
-Following these instructions will ensure your edits can be properly applied to the document.
+
+Following these instructions will ensure your create/edits of a file can be properly applied.
 `
-// Reused from Roocode. Thanks for the authors for keeping it open source.
+// Reused from Roocode. Thanks to the authors for keeping it open source.
 TOOL_UPDATE_TODO_LIST_DESCRIPTION = `## update_todo_list
 
 **Description:**

--- a/src/services/model-service.ts
+++ b/src/services/model-service.ts
@@ -195,16 +195,16 @@ export class ModelService {
     selectDefaultModel = async (modelType: ModelType, persistenceKey: string) => {
         const defaultModel = this.app.persistence.getGlobalValue(persistenceKey);
         if (defaultModel) {
-            await this.app.modelService.selectStartModel(defaultModel, modelType, this.app.modelService.getTypeDetails(modelType));
+            await this.selectStartModel(defaultModel, modelType, this.getTypeDetails(modelType));
         }
         this.app.llamaWebviewProvider.updateLlamaView();
     }
 
     public async selectStartModel(model: LlmModel, type: ModelType, details: ModelTypeDetails) {
         await this.addApiKey(model);
-        this.app.setSelectedModel(type, model);
-
+        
         await details.killCmd();
+        if (model.localStartCommand && this.app.configuration.only_one_local_model) await this.deselectAllLocalModels();
         if (model.localStartCommand) await details.shellCmd(this.sanitizeCommand(model.localStartCommand ?? ""));
         await this.app.persistence.setValue(this.getSelectedProp(type), model);
         if (type === ModelType.Tools) {
@@ -221,6 +221,18 @@ export class ModelService {
                 }
             }
         }
+
+        this.app.setSelectedModel(type, model);
+    }
+
+    private deselectAllLocalModels = async () => {
+        // Deselects models for completion, chat, tools if they are local
+        const complModel = this.app.getComplModel()
+        if (complModel && complModel.localStartCommand) await this.deselectAndClearModel(ModelType.Completion);
+        const chatModel = this.app.getChatModel()
+        if (chatModel && chatModel.localStartCommand) await this.deselectAndClearModel(ModelType.Chat);
+        const toolsModel = this.app.getToolsModel()
+        if (toolsModel && toolsModel.localStartCommand) await this.deselectAndClearModel(ModelType.Tools);
     }
 
     public async addModel(type: ModelType, kind: 'local' | 'external' | 'hf' | 'oaiComp'): Promise<void> {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -427,14 +427,17 @@ export class Tools {
     
     public editFile = async (args: string) => {
         let params = JSON.parse(args);
-        let changes = params.input;
+        let filePath = params.file_path;
+        let search = params.search;
+        let replace = params.replace;
+        let replaceAll = false
+        
+        if (params?.replace_all){
+            replaceAll = params?.replace_all;
+        }
 
-        if (params.input == undefined) return "The input is not provided."
-       
-        let filePath = this.getFilePath(params.input);
         if (!filePath) return "The file is not provided.";
         
-
         try {
             if (!this.app.configuration.tool_permit_file_changes){  
                 let [yesApply, yesDontAsk] = await this.confirmToolPermission(`Do you permit file ${filePath} to be changed?`)
@@ -444,11 +447,10 @@ export class Tools {
                 }
                 if (!yesApply) return Utils.MSG_NO_USER_PERMISSION;
             }
-            let resultEdit = await Utils.applyEdits(changes)
+            let resultEdit = await Utils.findReplaceFile(filePath, search, replace, replaceAll)
             if (resultEdit == UI_TEXT_KEYS.fileUpdated &&  this.app.configuration.rag_enabled && fs.existsSync(filePath)) {
                 this.app.chatContext.udpateFileIndexing(filePath, fs.readFileSync(filePath, 'utf-8'))
             }
-            const uri = vscode.Uri.file(Utils.getAbsolutFilePath(filePath));
             return resultEdit;
         } catch (error) {
             console.error('Error editing file ' + filePath + ":", error);
@@ -458,10 +460,8 @@ export class Tools {
 
     public editFileDesc = async (args: string) => {
         let params = JSON.parse(args);
-        let diffText = params.input;
-        if (!diffText) return "Parameter input not found."
-        
-        let filePath = this.getFilePath(diffText);
+        let filePath = params.file_path;
+        if (!filePath) return "Parameter file_path not found."
         
         return "Edited file " + filePath;
     }
@@ -830,18 +830,28 @@ export class Tools {
                 "type": "function",
                 "function": {
                     "name": "edit_file",
-                    "description": this.app.prompts.TOOL_APPLY_EDITS ,
+                    "description": this.app.prompts.EDIT_FILE_DESC ,
                     "parameters": {
                         "type": "object",
                         "properties": {
-                            "input": {
-                                "description": `Files changes in SEARCH/REPLACE block format. SEARCH should be EXACT MATCH, including spaces tabs, etc.`,
+                            "file_path": {
+                                "description": `Relative or absolute path of the file to edit/create. The file_path must be inside project root folder.`,
                                 "type": "string",
                             },
+                            "search": {
+                                "description": `The exact text to find and replace. Must be non-empty for edits. search should be EXACT MATCH, including spaces tabs, etc.`,
+                                "type": "string",
+                            },
+                            "replace": {
+                                "description": `The new content to insert. Can be an empty string to delete the search block.`,
+                                "type": "string",
+                            },
+                            "replace_all": {
+                                "description": `If true, replaces all occurrences of search. If false, search must appear exactly once.`,
+                                "type": "boolean",
+                            },
                         },
-                        "required": [
-                            "input"
-                        ],
+                        "required": ["file_path", "search", "replace"],
                     },
                     "strict": true
                 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,6 +17,7 @@ export class Tools {
     vscodeTools: any[] = [];
     vscodeToolsSelected: Map<string, boolean> = new Map();
     private lastSearchToolsResult: any[] = [];
+    private fileReadTimestamps = new Map<string, number>()
     
     constructor(application: Application) {
         this.app = application;
@@ -112,6 +113,9 @@ export class Tools {
         try {
             let absolutePath = Utils.getAbsolutFilePath(filePath);
             if (absolutePath == "") return "File not found: " + filePath
+            absolutePath = path.resolve(absolutePath) // Make the path unique for this file - no .. in the path
+            const stats = await fs.promises.stat(absolutePath);
+            this.fileReadTimestamps.set(absolutePath, stats.mtimeMs);
             uri = vscode.Uri.file(absolutePath);
             const document = await vscode.workspace.openTextDocument(uri)
             if (params.should_read_entire_file) return document.getText()
@@ -447,7 +451,7 @@ export class Tools {
                 }
                 if (!yesApply) return Utils.MSG_NO_USER_PERMISSION;
             }
-            let resultEdit = await Utils.findReplaceFile(filePath, search, replace, replaceAll)
+            let resultEdit = await Utils.findReplaceFile(filePath, search, replace, replaceAll, this.fileReadTimestamps)
             if (resultEdit == UI_TEXT_KEYS.fileUpdated &&  this.app.configuration.rag_enabled && fs.existsSync(filePath)) {
                 this.app.chatContext.udpateFileIndexing(filePath, fs.readFileSync(filePath, 'utf-8'))
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -506,63 +506,93 @@ export class Utils {
         return currentContent;
     }
 
-    static  applyEdits = async (diffText: string): Promise<string> => {
+    /**
+ * Removes the UTF-8 / UTF-16 BE BOM from the start of a string.
+ * Returns the original string if no BOM is found.
+ */
+    static stripBOMFromString = (content: string): string => {
+    // charCodeAt(0) === 0xFEFF is the BOM marker
+    if (content.charCodeAt(0) === 0xFEFF) {
+        return content.slice(1);
+    }
+    return content;
+    }
+
+    /**
+     * Checks if `substring` appears exactly once in `str`.
+     * @param str - The string to search in.
+     * @param sub - The substring to search for.
+     * @returns 0 if not found 1 if found once 2 if found more than once.
+     */
+    static containsSubstringInfo = (str: string, sub: string): number => {
+        // Empty substring appears at every index; treat as not exactly once.
+        if (sub === "") return 0;
+
+        const firstIndex = str.indexOf(sub);
+        if (firstIndex === -1) return 0;
+
+        const lastIndex = str.lastIndexOf(sub);
+        if (firstIndex === lastIndex) return 1;
+        else return 2;
+    }
+
+    static  findReplaceFile = async (filePath: string, searchText: string, replaceText: string, replaceAll: boolean): Promise<string> => {
         // Extract edit blocks from the diff-fenced format
         let ret = UI_TEXT_KEYS.fileUpdated as string;
-        let editBlocks: string[][] = [];
-        if (!diffText) return "Edit file: The input parameter is missing!";
-        const blocks = diffText.split("```diff")
-        for (const block of blocks.slice(1)){
-            editBlocks.push(Utils.extractConflictParts("```diff" + block))
-        }
-
-        if (editBlocks.length === 0) {
-            if (diffText.length > 0) editBlocks.push(Utils.extractConflictParts("```diff\n" + diffText))
-            else return "Edit file: The input parameter is missing or incorrect format!";
-        }
-
-        for (const block of editBlocks) {
-            if (block.length === 3) {
-                let filePath = block[0].trim();
-                if (filePath.startsWith("<file_path>")) filePath = filePath.slice("<file_path>".length);
-                if (filePath.endsWith("</file_path>")) filePath = filePath.slice(0,-"</file_path>".length)
-                let searchText = block[1].trim();
-                // Make sure only \n is used for new line
-                searchText = searchText.split(/\r?\n/).join("\n");
-                const replaceText = block[2].trim();
-                
-                let result = "";
-                let absolutePath = filePath;
-                if (!path.isAbsolute(filePath)) {
-                    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-                        return "File not found: " + filePath;
-                    }
-                    const workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
-                    absolutePath = path.join(workspaceRoot, filePath);
-                }
-                try {
-                    const fileExists = await fs.promises.access(absolutePath).then(() => true).catch(() => false);
-                    if (!fileExists){
-                        await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
-                        await fs.promises.writeFile(absolutePath, result);
-                    }
-                    // Ensure only \n is used for new line
-                    result = (await fs.promises.readFile(absolutePath, 'utf-8')).split(/\r?\n/).join("\n");
-                    // Handle empty search text case
-                    if (searchText.trim() === '') {
-                        result += '\n' + replaceText;
-                        await fs.promises.writeFile(absolutePath, result);
-                    } else if (result.includes(searchText)) {
-                        result = result.split(searchText).join(replaceText);
-                        await fs.promises.writeFile(absolutePath, result);
-                    } else {
-                        ret = "Error edititing file " + filePath + " - " + "The search text is not found in the file.";
-                    }                    
-                } catch (error) {
-                    if (error instanceof Error) ret = "Error edititing file " + filePath + " - " + error.message;
-                    else ret = "Error edititing file " + filePath + " - " + error;
-                }
+        let result = "";
+        let absolutePath = filePath;
+        if (!path.isAbsolute(filePath)) {
+            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+                return "File not found: " + filePath;
             }
+            const workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
+            absolutePath = path.join(workspaceRoot, filePath);
+        } else {
+            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+                return "No project folder found. Only files inside projet folder can be edited.";
+            }
+            const workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
+            const root = path.resolve(workspaceRoot);
+            const file = path.resolve(filePath);
+            const relative = path.relative(root, file);
+            const  isInsideWorkspace = !relative.startsWith('..') && !path.isAbsolute(relative)
+            if (!isInsideWorkspace) return "The file not is not in project folder: " + filePath;
+        }
+        try {
+            const fileExists = await fs.promises.access(absolutePath).then(() => true).catch(() => false);
+            if (!fileExists){
+                await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
+                await fs.promises.writeFile(absolutePath, result);
+            }
+            // Ensure only \n is used for new line
+            result = (await fs.promises.readFile(absolutePath, 'utf-8')).split(/\r?\n/).join("\n");
+            result = Utils.stripBOMFromString(result);
+            
+            // Handle empty search text case
+            searchText = searchText.split(/\r?\n/).join("\n");
+            if (searchText.trim() === '') {
+                if (fs.existsSync(absolutePath)){
+                    result += '\n' + replaceText;
+                    await fs.promises.writeFile(absolutePath, result);
+                    return "The file is created: " + absolutePath
+                } else {
+                    ret = "File already exists. Use edit mode (non-empty search) to modify it."
+                }
+            } else {
+                if (!fs.existsSync(absolutePath)) {
+                    return "Cannot edit a non-existent file. To create a file, set search to an empty string."
+                }
+                const foundTimes = Utils.containsSubstringInfo(result, searchText);
+                if (foundTimes == 1 || (foundTimes > 1 && replaceAll)) {
+                    result = result.split(searchText).join(replaceText);
+                    await fs.promises.writeFile(absolutePath, result);
+                } else if (foundTimes == 0) {
+                    ret = "Error edititing file " + filePath + " - " + "Search string not found.";
+                } else ret = "Error edititing file " + filePath + " - " + "Found more than one matches. Provide more context or set replace_all=true.";
+            }                 
+        } catch (error) {
+            if (error instanceof Error) ret = "Error edititing file " + filePath + " - " + error.message;
+            else ret = "Error edititing file " + filePath + " - " + error;
         }
         
         return ret;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -507,9 +507,9 @@ export class Utils {
     }
 
     /**
- * Removes the UTF-8 / UTF-16 BE BOM from the start of a string.
- * Returns the original string if no BOM is found.
- */
+     * Removes the UTF-8 / UTF-16 BE BOM from the start of a string.
+     * Returns the original string if no BOM is found.
+     */
     static stripBOMFromString = (content: string): string => {
     // charCodeAt(0) === 0xFEFF is the BOM marker
     if (content.charCodeAt(0) === 0xFEFF) {
@@ -536,67 +536,99 @@ export class Utils {
         else return 2;
     }
 
-    static  findReplaceFile = async (filePath: string, searchText: string, replaceText: string, replaceAll: boolean): Promise<string> => {
-        // Extract edit blocks from the diff-fenced format
-        let ret = UI_TEXT_KEYS.fileUpdated as string;
-        let result = "";
-        let absolutePath = filePath;
-        if (!path.isAbsolute(filePath)) {
-            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-                return "File not found: " + filePath;
-            }
-            const workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
-            absolutePath = path.join(workspaceRoot, filePath);
-        } else {
-            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-                return "No project folder found. Only files inside projet folder can be edited.";
-            }
-            const workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
-            const root = path.resolve(workspaceRoot);
-            const file = path.resolve(filePath);
-            const relative = path.relative(root, file);
-            const  isInsideWorkspace = !relative.startsWith('..') && !path.isAbsolute(relative)
-            if (!isInsideWorkspace) return "The file not is not in project folder: " + filePath;
-        }
+    static findReplaceFile = async (
+        filePath: string, 
+        searchText: string, 
+        replaceText: string, 
+        replaceAll: boolean,
+        fileReadTimestamps: Map<string, number>
+    ): Promise<string> => {
         try {
-            const fileExists = await fs.promises.access(absolutePath).then(() => true).catch(() => false);
-            if (!fileExists){
-                await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
-                await fs.promises.writeFile(absolutePath, result);
-            }
-            // Ensure only \n is used for new line
-            result = (await fs.promises.readFile(absolutePath, 'utf-8')).split(/\r?\n/).join("\n");
-            result = Utils.stripBOMFromString(result);
-            
-            // Handle empty search text case
-            searchText = searchText.split(/\r?\n/).join("\n");
-            if (searchText.trim() === '') {
-                if (fs.existsSync(absolutePath)){
-                    result += '\n' + replaceText;
-                    await fs.promises.writeFile(absolutePath, result);
-                    return "The file is created: " + absolutePath
-                } else {
-                    ret = "File already exists. Use edit mode (non-empty search) to modify it."
+            // --- 1. Resolve path against workspaces ---
+            let absolutePath: string = filePath;
+            if (path.isAbsolute(filePath)) {
+                const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+                if (!workspaceFolder) {
+                    return `Error: File "${filePath}" is outside all workspace folders.`;
                 }
+                absolutePath = path.resolve(filePath);
             } else {
-                if (!fs.existsSync(absolutePath)) {
-                    return "Cannot edit a non-existent file. To create a file, set search to an empty string."
+                if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+                    return "Error: No workspace folder found.";
                 }
-                const foundTimes = Utils.containsSubstringInfo(result, searchText);
-                if (foundTimes == 1 || (foundTimes > 1 && replaceAll)) {
-                    result = result.split(searchText).join(replaceText);
-                    await fs.promises.writeFile(absolutePath, result);
-                } else if (foundTimes == 0) {
-                    ret = "Error edititing file " + filePath + " - " + "Search string not found.";
-                } else ret = "Error edititing file " + filePath + " - " + "Found more than one matches. Provide more context or set replace_all=true.";
-            }                 
+                let resolved = false;
+                for (const folder of vscode.workspace.workspaceFolders) {
+                    const potential = path.join(folder.uri.fsPath, filePath);
+                    const relative = path.relative(folder.uri.fsPath, potential);
+                    if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
+                        absolutePath = potential;
+                        resolved = true;
+                        break;
+                    }
+                }
+                if (!resolved) {
+                    return `Error: Cannot resolve relative path "${filePath}" against any workspace folder.`;
+                }
+            }
+
+            // --- 2. Check file existence ---
+            const fileExists = await fs.promises.access(absolutePath).then(() => true).catch(() => false);
+
+            // --- 3. Read content if exists ---
+            let content = "";
+            if (fileExists) {
+                content = (await fs.promises.readFile(absolutePath, 'utf-8')).split(/\r?\n/).join("\n");
+                content = Utils.stripBOMFromString(content);
+            }
+
+            // --- 4. Normalize searchText ---
+            const normalizedSearch = searchText.split(/\r?\n/).join("\n");
+
+            // --- 5. Creation mode ---
+            if (normalizedSearch.trim() === '') {
+                if (fileExists) {
+                    return `Error: File already exists at "${absolutePath}". Use edit mode (non-empty search) to modify it.`;
+                }
+                await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
+                await fs.promises.writeFile(absolutePath, replaceText, 'utf-8');
+                return `Success: File created at "${absolutePath}".`;
+            }
+
+            // --- 6. Edit mode ---
+            if (!fileExists) {
+                return `Error: Cannot edit non-existent file "${absolutePath}". To create it, set search to an empty string.`;
+            }
+
+            // --- 7. Staleness check (recommended addition) ---
+            const stats = await fs.promises.stat(absolutePath);
+            const lastModified = fileReadTimestamps.get(absolutePath);
+            if (lastModified && stats.mtimeMs !== lastModified) {
+                return `Error: File "${absolutePath}" was modified externally since last read. Re-read the file and retry.`;
+            }
+
+            // --- 8. Uniqueness check ---
+            const matchCount = Utils.containsSubstringInfo(content, normalizedSearch);
+            if (matchCount === 0) {
+                return `Error: Search string not found in "${filePath}".`;
+            }
+            if (matchCount > 1 && !replaceAll) {
+                return `Error: Found ${matchCount} matches in "${filePath}". Provide more context or set replace_all=true.`;
+            }
+
+            // --- 9. Perform replacement ---
+            const newContent = content.split(normalizedSearch).join(replaceText);
+            await fs.promises.writeFile(absolutePath, newContent, 'utf-8');
+
+            // Update timestamp
+            const newStats = await fs.promises.stat(absolutePath);
+            fileReadTimestamps.set(absolutePath, newStats.mtimeMs);
+
+            return `Success: File "${filePath}" updated.`;
+
         } catch (error) {
-            if (error instanceof Error) ret = "Error edititing file " + filePath + " - " + error.message;
-            else ret = "Error edititing file " + filePath + " - " + error;
+            return `Error editing file "${filePath}": ${error instanceof Error ? error.message : String(error)}`;
         }
-        
-        return ret;
-    }
+    };
 
     static extractConflictParts = (input: string): [string, string, string] => {
         const lines = input.split(/\r?\n/);


### PR DESCRIPTION
- Tool edit_file is reimplemented - now it uses simple search/replace and requires the file to be read after the latest modification
- Property only_one_local_model added for ease of use with local models. If true - on selecting a local model, the other selected local models are deselected/stopped. This is valid for completion, chat and tools models. Embeddings models are small and therefore excuded from the group. By default it is false.
