### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,40 @@ The extension includes Llama Agent
 2. Select Env with an agent if you haven't done it before. 
 3. Write a query and attach files with the @ button if needed
 
-More details(https://github.com/ggml-org/llama.vscode/wiki) 
+More details(https://github.com/ggml-org/llama.vscode/wiki)
+
+### Phone spectator (Build Remote Agent)
+
+Optional. Pair a phone running [Build Remote Agent](https://grokbuildremote.com/)
+to spectate Llama Agent through the free MIT `gbr-agent`. Protocol `gbr/1`.
+This does **not** replace the Telegram bot. Phone is spectator + veto, not
+orchestrator. Independent product by Linespotting AB. Not affiliated with xAI
+or SpaceX.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Then add a VS Code MCP server (stdio) and enable it in Llama Agent's MCP tool
+list:
+
+```json
+{
+  "servers": {
+    "gbr": {
+      "command": "node",
+      "args": ["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+    }
+  }
+}
+```
+
+Attach is loopback only: `http://127.0.0.1:8788/health` after `gbr-agent run`.
+Do not commit mailbox keys.
+
+Agent source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
 
 ## Examples
 


### PR DESCRIPTION
## Pair a phone with Build Remote Agent

Adds a short how-to so a phone running **Build Remote Agent** can spectate this desktop agent through the free MIT `gbr-agent`.

- Protocol: `gbr/1`
- Attach only: `http://127.0.0.1:8788` after `gbr-agent run`, or MCP stdio `gbr-mcp`
- Phone is spectator + veto, not orchestrator
- No mailbox keys, no new pair protocol

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version   # v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.

Website: https://grokbuildremote.com/
Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)

Useful adapter docs for maintainers to merge, edit, or close.
